### PR TITLE
README says what the engine now does, and provider-login stops offering Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ pinned MCP catalog, one copy of every rule:
 | --- | --- | --- |
 | A website | Next.js 16 · React 19 · Tailwind v4 · shadcn/ui · MagicUI | nothing |
 | A database | Convex | run `npx convex dev` once |
-| Sign in | Better Auth, wired — no screens | connect Convex |
-| Payments | Stripe hosted checkout, webhook entitlement | authorize, secrets only in Convex |
+| Sign in | Better Auth, wired — email + password, Google and GitHub, no screens | connect Convex |
+| Payments | Stripe hosted checkout, webhook entitlement | `pnpm provider:login stripe`, then provision |
 | Email | Resend | authorize, secrets only in Convex |
 | Analytics | PostHog, proxied on your own origin | add the public key |
 | Deploy | Netlify (`netlify.toml`) | `netlify init` then `netlify deploy --prod` |
@@ -61,12 +61,18 @@ through resumable handoffs; credentials never enter chat, state, or the repo.
 
 | Command | Answers |
 | --- | --- |
-| `pnpm health` | is anything wrong — every failure includes the fix |
+| `pnpm health` | is anything wrong — including what only the deployment knows, like a Stripe secret key with no webhook secret behind it |
 | `pnpm verify` | is my work actually finished |
 | `pnpm verify:full` | release gates: audit, unit tests, production browser suite |
 | `pnpm heal` | can it fix itself (links, mirrors, lockfile), with proof |
 | `pnpm onboard --host <host>` | which provider does this product still need |
+| `pnpm provider:login <cli>` | authorize a vendor through its own browser OAuth |
 | `pnpm preflight --prod` | am I actually ready to launch |
+
+Provider keys are graded as **combinations**, not one at a time, because that is where
+the damage lives: each key is individually valid while a secret key with no webhook
+secret means the customer pays and never gets the plan. The checks read env *names* from
+the connected deployment — never a value.
 
 ## Works with any agent
 
@@ -82,7 +88,7 @@ Host marks above are vendored, not hotlinked — provenance in
 
 - [AGENTS.md](AGENTS.md) — every rule, in one file
 - [.agents/skills/](.agents/skills) — procedures: product lifecycle, connections, UI, backend, security, testing, launch
-- [.agents/agents/](.agents/agents) — the five specialist role briefs
+- [.agents/agents/](.agents/agents) — five specialist role briefs, plus the vendor-generated Playwright trio
 
 ## License
 

--- a/scripts/provider-login.mjs
+++ b/scripts/provider-login.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * pnpm provider:login <stripe|render|netlify|github|21st>
+ * pnpm provider:login <stripe|netlify|github|21st>
  *
  * One journey per provider: install the official CLI if it is missing, then run its
  * browser OAuth login and wait for consent. The terminal never carries a credential —
@@ -39,26 +39,6 @@ const PROVIDERS = {
     login: ["stripe", "login"],
     captureAndComplete: true,
     verify: ["stripe", "products", "list", "--limit", "1"],
-  },
-  render: {
-    binary: "render",
-    docs: "https://render.com/docs/cli",
-    // The CLI writes $HOME/.render/cli.yaml, NOT .config/render/config.json. The old
-    // path meant `verified()` never found a paired install, so this provider always
-    // reported itself unauthenticated no matter how many times login succeeded.
-    pairedFile: join(".render", "cli.yaml"),
-    install: {
-      darwin: [["brew", "install", "render"]],
-      linux: [["brew", "install", "render"]],
-      win32: null,
-    },
-    login: ["render", "login"],
-    feedEnter: true,
-    // A token alone is not a usable pairing here: every other render command fails with
-    // "no workspace set" until one is chosen, so the read-only probe has to be one of
-    // the commands that actually needs a workspace.
-    verify: ["render", "services", "-o", "json", "--confirm"],
-    afterLogin: selectRenderWorkspace,
   },
   netlify: {
     binary: "netlify",
@@ -116,38 +96,6 @@ function verified(provider) {
   return result.status === 0;
 }
 
-/**
- * Render's login saves a token but leaves the CLI with no active workspace, and every
- * command except `workspaces` and `whoami` then fails. Picking one is a real choice, so
- * it is only made automatically when there is exactly ONE — with several, which
- * workspace a project deploys into is the user's decision and the script says so rather
- * than guessing.
- */
-function selectRenderWorkspace() {
-  const current = spawnSync("render", ["workspace", "current", "-o", "json", "--confirm"], { stdio: "ignore" });
-  if (current.status === 0) return;
-
-  const listed = spawnSync("render", ["workspaces", "-o", "json", "--confirm"], { encoding: "utf8" });
-  if (listed.status !== 0) return;
-
-  let workspaces = [];
-  try {
-    workspaces = JSON.parse(listed.stdout ?? "[]") ?? [];
-  } catch {
-    return;
-  }
-
-  if (workspaces.length === 1) {
-    const only = workspaces[0];
-    run(["render", "workspace", "set", only.id, "--confirm", "-o", "text"]);
-    return;
-  }
-  if (workspaces.length > 1) {
-    console.log("\nrender: several workspaces are available. Choose the one this project deploys into:");
-    for (const workspace of workspaces) console.log(`  ${workspace.name}  (${workspace.id})`);
-    console.log("Then run: render workspace set <workspaceID>");
-  }
-}
 
 function completeHeadlessPairing(loginOutput) {
   const start = loginOutput.indexOf("{");


### PR DESCRIPTION
Audited every claim in the README against the repo rather than proof-reading the prose. All six commands exist in `package.json`, and every relative link resolves. Three things had gone stale, and one real drift turned up.

## Stale claims

**Sign in** — now email + password *and* Google and GitHub, enabled per provider when both halves of a credential pair are present.

**`pnpm health`** — it no longer only reads files. It asks the connected deployment and grades provider keys as **combinations**, which is the part no file check could ever see: each key is individually valid while a secret key with no webhook secret means the customer pays and never gets the plan. Added a short note that it reads env *names*, never values.

**Role briefs** — `.agents/agents/` has eight files: five authored, plus the vendor-generated Playwright trio. "The five specialist role briefs" described the directory inaccurately.

Also pointed the Payments row at `pnpm provider:login stripe`, since that is now the actual entry point.

## The drift

`scripts/provider-login.mjs` still listed **render** in its usage string and `PROVIDERS` after Netlify replaced it. AGENTS.md's command table already read `(stripe, netlify, github, 21st)` — and when a script and the declared rules disagree, the rules win. Removed the entry and its workspace-selection helper. The generic `afterLogin` hook stays, since the next provider whose credential needs a machine-local follow-up step will want it.

`pnpm verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)