### PR TITLE
Restore installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,45 @@ The tool provides one canonical set of rules, skills, contracts, agent briefs, M
 wiring, visual-direction and visual-QA procedures, durable work coordination, and
 connection handoffs across Codex, Claude Code, Cursor, Hermes, and OpenClaw.
 
-## Use
+## Install
+
+Use `npx` to launch the zero-dependency installer from GitHub:
 
 ```bash
+npx github:moasq/create-agentic-ship agentic-ship
+cd agentic-ship
+pnpm verify
+```
+
+If you prefer pnpm as the package runner, `pnpm dlx` is equivalent:
+
+```bash
+pnpm dlx github:moasq/create-agentic-ship agentic-ship
+cd agentic-ship
+pnpm verify
+```
+
+`npx` or `pnpm dlx` downloads and runs the installer. The installed Agentic Ship
+checkout itself uses `pnpm` for synchronization, health, review, and verification.
+
+To install the skills into Codex instead of creating a standalone checkout, ask Codex:
+
+```text
+Install every skill from https://github.com/moasq/agentic-ship/tree/main/.agents/skills using the built-in skill installer.
+```
+
+Claude Code can install the same repository as a marketplace plugin:
+
+```text
+/plugin marketplace add moasq/agentic-ship
+/plugin install agentic-ship@agentic-ship
+```
+
+## Develop the tool locally
+
+```bash
+git clone https://github.com/moasq/agentic-ship.git
+cd agentic-ship
 pnpm install
 pnpm verify
 ```

--- a/skills.lock.json
+++ b/skills.lock.json
@@ -184,7 +184,7 @@
   "installer": {
     "command": "npx github:moasq/create-agentic-ship my-app",
     "repo": "https://github.com/moasq/create-agentic-ship",
-    "verified": "2026-08-04",
+    "verified": "2026-08-09",
     "design": "Zero dependencies, in its own repo. npx installs a package before running it, so any dependency is time the user spends waiting — and npm cannot install from a subdirectory of this repo, which rules out shipping the CLI here. It downloads the GitHub tarball and unpacks it with node:zlib plus a ~40-line tar reader: no git, no curl, no tar binary, no shell, so it behaves the same on Windows.",
     "notes": "The .claude/skills symlink is skipped by the tarball (symlink entries are not extracted) and recreated by postinstall's link-skills — the same repair path that fixes Windows checkouts. Publishing to npm would shorten the command to `npx create-agentic-ship`; that needs the owner's npm account."
   },


### PR DESCRIPTION
Restores the practical install section after the tool-only consolidation. Documents the tested npx bootstrap command, the equivalent pnpm dlx form, Codex's built-in skill-installer prompt, Claude Code plugin commands, and local tool development. Also refreshes the installer verification receipt.\n\nVerified with a real public npx install from moasq/create-agentic-ship and pnpm verify:full.