### PR TITLE
feat: define replaceable provider adapter contracts

### DIFF
--- a/.agents/connections/providers.json
+++ b/.agents/connections/providers.json
@@ -3,6 +3,8 @@
   "providers": {
     "convex": {
       "displayName": "Convex",
+      "capability": "backend",
+      "defaultForCapability": true,
       "docsUrl": "https://docs.convex.dev/cli",
       "actionTtlMinutes": 1440,
       "maxVerificationAttempts": 5,
@@ -143,9 +145,26 @@
     },
     "stripe": {
       "displayName": "Stripe",
+      "capability": "billing",
+      "defaultForCapability": true,
       "docsUrl": "https://docs.stripe.com/stripe-cli",
       "actionTtlMinutes": 1440,
       "maxVerificationAttempts": 5,
+      "billing": {
+        "ownedEnvPrefixes": ["STRIPE_"],
+        "secretEnv": "STRIPE_SECRET_KEY",
+        "webhookEnv": "STRIPE_WEBHOOK_SECRET",
+        "requiredEnv": ["SITE_URL"],
+        "mappingEnvPrefix": "STRIPE_PRICE_",
+        "productionChecks": [
+          {
+            "type": "matches",
+            "env": "STRIPE_SECRET_KEY",
+            "pattern": "^(sk|rk)_live_",
+            "message": "Stripe requires a live secret key in production."
+          }
+        ]
+      },
       "agentTool": {
         "authFlow": "cli_browser_login",
         "mcpServer": "stripe",
@@ -232,6 +251,8 @@
     },
     "github": {
       "displayName": "GitHub",
+      "capability": "repository",
+      "defaultForCapability": true,
       "docsUrl": "https://cli.github.com/manual/",
       "actionTtlMinutes": 1440,
       "maxVerificationAttempts": 5,
@@ -294,6 +315,8 @@
     },
     "linear": {
       "displayName": "Linear",
+      "capability": "tracking",
+      "defaultForCapability": true,
       "docsUrl": "https://linear.app/docs/mcp",
       "actionTtlMinutes": 1440,
       "maxVerificationAttempts": 5,
@@ -348,6 +371,8 @@
     },
     "resend": {
       "displayName": "Resend",
+      "capability": "email",
+      "defaultForCapability": true,
       "docsUrl": "https://resend.com/docs",
       "actionTtlMinutes": 1440,
       "maxVerificationAttempts": 5,
@@ -432,6 +457,8 @@
     },
     "posthog": {
       "displayName": "PostHog",
+      "capability": "analytics",
+      "defaultForCapability": true,
       "docsUrl": "https://posthog.com/docs",
       "actionTtlMinutes": 1440,
       "maxVerificationAttempts": 5,
@@ -517,6 +544,8 @@
     },
     "netlify": {
       "displayName": "Netlify",
+      "capability": "deployment",
+      "defaultForCapability": true,
       "docsUrl": "https://docs.netlify.com/cli/get-started/",
       "actionTtlMinutes": 1440,
       "maxVerificationAttempts": 5,

--- a/.agents/contracts/product-brief.schema.json
+++ b/.agents/contracts/product-brief.schema.json
@@ -4,9 +4,9 @@
   "title": "Product brief",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "product", "capabilities", "constraints", "quality"],
+  "required": ["schemaVersion", "product", "capabilities", "constraints", "providerSelection", "quality"],
   "properties": {
-    "schemaVersion": { "const": 1 },
+    "schemaVersion": { "const": 2 },
     "product": {
       "type": "object",
       "additionalProperties": false,
@@ -37,6 +37,7 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
     },
+    "providerSelection": { "$ref": "provider-selection.schema.json" },
     "providers": {
       "type": "array",
       "items": {

--- a/.agents/contracts/provider-selection.schema.json
+++ b/.agents/contracts/provider-selection.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-workspace.dev/contracts/provider-selection.schema.json",
+  "title": "Provider selection",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["billing", "email", "analytics", "deployment", "tracking"],
+  "properties": {
+    "billing": { "$ref": "#/$defs/providerId", "default": "stripe" },
+    "email": { "$ref": "#/$defs/providerId", "default": "resend" },
+    "analytics": { "$ref": "#/$defs/providerId", "default": "posthog" },
+    "deployment": { "$ref": "#/$defs/providerId", "default": "netlify" },
+    "tracking": {
+      "oneOf": [{ "$ref": "#/$defs/providerId" }, { "type": "null" }],
+      "default": "linear"
+    }
+  },
+  "$defs": {
+    "providerId": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    }
+  }
+}

--- a/.agents/skills/convex-structure/SKILL.md
+++ b/.agents/skills/convex-structure/SKILL.md
@@ -206,6 +206,10 @@ Never in `.env.local`, never in Next's env. The only Convex values Next sees are
 `NEXT_PUBLIC_CONVEX_URL` and `NEXT_PUBLIC_CONVEX_SITE_URL` — both URLs, both public by
 design.
 
+Before writing billing code, read the reference for the provider selected in the product
+brief. Stripe uses `references/stripe-billing.md`. A provider reference may add setup
+details, but it cannot weaken the billing invariants declared in `AGENTS.md`.
+
 ## 9. Adding a feature — the fixed sequence
 
 1. Table + indexes in `schema.ts`

--- a/.agents/skills/product-lifecycle/SKILL.md
+++ b/.agents/skills/product-lifecycle/SKILL.md
@@ -10,7 +10,7 @@ Use repository state as the coordination layer. Chat context is helpful, but it 
 ## Start with an outcome contract
 
 1. Write a product brief that conforms to `.agents/contracts/product-brief.schema.json`.
-2. Keep the user's problem, audience, outcomes, non-goals, provider needs, and definition of done explicit.
+2. Keep the user's problem, audience, outcomes, non-goals, provider needs, and definition of done explicit. Record one provider per capability in `providerSelection`. Use a catalog default only when the user has not chosen an alternative.
 3. Turn each independently verifiable capability into a feature contract conforming to `.agents/contracts/feature-contract.schema.json`.
 4. Initialize the durable queue with `pnpm agent:work init --name <product> --goal <outcome>`.
 5. Add work with one owner role and at least one acceptance criterion. Dependencies must already exist, which forces the queue into a reviewable order.

--- a/.agents/skills/production-preflight/SKILL.md
+++ b/.agents/skills/production-preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: production-preflight
-description: The go-live gate — verify production is REAL before launch: live Stripe keys in the prod deployment, email out of testMode with verification on, no test-seed backdoor, real URLs and webhooks. Run before the first deploy and after any config change that touches money, email, or auth.
+description: The go-live gate. Verify the selected billing provider is live, email leaves testMode with verification on, URLs are real, and no test-seed backdoor exists. Run before the first deploy and after any money, email, or auth change.
 ---
 
 # Production preflight
@@ -30,9 +30,9 @@ Exit 1 on any FAIL. Run `--prod` before every launch; the plain form on every de
 | `requireEmailVerification: true` in `convex/auth.ts` | unverified addresses sign up |
 | the two above flip **together** | either alone is broken — `pnpm health` enforces the pair in dev too |
 | `src/lib/site.ts` has no scaffold placeholders | "My App" as your `<title>`, OG card and llms.txt |
-| prod `STRIPE_SECRET_KEY` is `sk_live_`/`rk_live_` | **production takes test payments** |
-| prod `STRIPE_WEBHOOK_SECRET` set | payments succeed but entitlements never flip |
-| a `STRIPE_PRICE_*` exists in prod | checkout cannot resolve any plan |
+| selected billing adapter passes its production checks | production uses test payments or the wrong provider environment |
+| selected billing webhook secret is set | payments succeed but entitlements never flip |
+| selected billing plan mappings exist | checkout cannot resolve any plan |
 | prod `RESEND_API_KEY` + `EMAIL_FROM` on a verified domain (not `resend.dev`) | email dies silently after launch |
 | prod `SITE_URL` is https and not localhost | auth callbacks and email links point at your laptop |
 | prod `BETTER_AUTH_SECRET` set | sessions cannot be issued |
@@ -43,13 +43,12 @@ Exit 1 on any FAIL. Run `--prod` before every launch; the plain form on every de
 
 ## The judgment half (yours, or the agent's — not scriptable)
 
-1. **Webhooks point at prod.** Stripe: a dashboard endpoint at
-   `https://<prod-deployment>.convex.site/stripe/webhook` with the documented events —
-   the `stripe listen` secret is dev-only and does not carry over. Resend: same for
-   `/resend-webhook`. Verify by sending a test event from each dashboard.
-2. **Acceptance test on prod:** one real checkout in live mode with a real card,
-   refunded immediately — the entitlement must flip reload-free. Stripe test clocks
-   cover renewals; only a live transaction proves the live pipeline.
+1. **Webhooks point at prod.** Register the selected billing adapter's production
+   endpoint and events. Development listener secrets do not carry over. Register
+   Resend at `/resend-webhook`. Send a test event from each provider dashboard.
+2. **Acceptance test on prod:** complete one live checkout with a real payment method,
+   then refund it. Entitlement must update without a reload. Sandbox simulations cover
+   renewals, but only a live transaction proves the production pipeline.
 3. **Email round trip on prod:** sign up with a real address, receive the
    verification, complete it.
 4. **Rollback story:** know the last green deploy in Netlify before you need it.
@@ -63,7 +62,7 @@ Same order as deploy-netlify's go-live checklist — the two documents deliberat
 
 1. Verify the sending domain in Resend → set prod `EMAIL_FROM`. Preparation only —
    nothing sends yet while `testMode` holds.
-2. Live Stripe keys + prod webhook + live `STRIPE_PRICE_*` — into **prod Convex env**
+2. Select the billing provider, then set its production credentials, webhook, and plan mappings in **prod Convex env**
 3. Only then: `testMode: false` + `requireEmailVerification: true`, one commit —
    real mail invites real users, so money goes real before mail does
 4. `SITE_URL` / `NEXT_PUBLIC_SITE_URL` to the real host

--- a/.agents/skills/service-connections/references/protocol.md
+++ b/.agents/skills/service-connections/references/protocol.md
@@ -75,9 +75,11 @@ payloads.
 
 ## Adding a provider
 
-Add a provider entry to `.agents/connections/providers.json`. Declare both
-`agentTool` and `projectProvisioning`, even when one is minimal. Use only the supported
-local probe types:
+Add a provider entry to `.agents/connections/providers.json`. Set `capability` and
+`defaultForCapability`, then declare `projectProvisioning`. Declare `agentTool` only
+when an official CLI or host MCP integration can authorize and verify the connection.
+Providers without one start at project provisioning. Use only the supported local probe
+types:
 
 - `mcp_server`
 - `file_exists`
@@ -92,3 +94,8 @@ local probe types:
 Choose `machine` only when local, non-secret signals prove readiness. Choose
 `probe_and_attestation` when provider dashboard state cannot be inspected safely. Add
 tests for the new policy and run the catalog validator through the connection service.
+
+Billing providers also declare a `billing` adapter. It owns the provider's environment
+prefixes, secret and webhook names, plan mapping prefix, and production value checks.
+The shared coherence and preflight code reads that data. Adding a billing provider must
+not add a provider-specific branch to either dispatcher.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,8 +169,10 @@ matrix through `visual-qa` before completion.
 ## Agentic workflow
 
 - Start product-sized work with a brief conforming to
-  `.agents/contracts/product-brief.schema.json`. Give every feature one owner, explicit
-  scope, interfaces, dependencies, and acceptance criteria through the feature contract.
+  `.agents/contracts/product-brief.schema.json`. The brief selects one provider for
+  billing, email, analytics, deployment, and tracking. Give every feature one owner,
+  explicit scope, interfaces, dependencies, and acceptance criteria through the
+  feature contract.
 - Use `pnpm agent:work` for durable coordination. A host or chat may disappear; the
   work queue must still identify what is ready, in progress, waiting for a person,
   blocked, or done. Completion always carries gate evidence.
@@ -217,6 +219,8 @@ matrix through `visual-qa` before completion.
 - Keep three connection types separate: AI-host MCP authorization, application project
   provisioning, and the product customer's runtime redirect. A Stripe customer returns
   from hosted Checkout, but entitlement still comes only from the webhook-backed query.
+- A provider with no official CLI or host MCP integration starts at project provisioning.
+  Never invent an agent-tool authorization phase or attest to an unverified connection.
 - Native adapters are generated artifacts. Edit `.agents/agents/` or `.mcp.json`, then
   regenerate; never patch `agents/`, `.codex/agents/`, `.cursor/agents/`, or
   `.cursor/mcp.json` directly.
@@ -471,10 +475,31 @@ needs, against these seams, when the user asks for them:
   gets the narrow compile-checked compatibility bridge. Only `upstream-sync` moves the
   pin after the audit, type, unit, build, and browser gates pass.
 
-## Billing rules (Stripe, wired)
+## Billing rules (replaceable provider, Stripe default)
 
-Same shape: engine wired, **no billing UI shipped** — the seams and the rules are the
-product. Full flow and rule list: `.agents/skills/convex-structure/references/stripe-billing.md`.
+The engine ships no billing UI. A product brief selects one billing provider, and the
+deployment repeats that choice in `BILLING_PROVIDER`. Stripe remains the default when
+the variable is absent, so existing products keep their current behavior. Each adapter
+owns its environment names, setup checks, production checks, and reference document.
+
+Every billing adapter must preserve these invariants:
+
+- The browser sends a plan key, never an amount or provider price ID.
+- Checkout and portal sessions come from the selected provider's hosted surfaces.
+- Authenticated context supplies user or organization references. The browser never
+  supplies an identity that the backend trusts.
+- A verified webhook or verified customer state is the only entitlement writer. A
+  checkout return URL never grants access.
+- Webhook handling is idempotent, rejects invalid signatures, and ignores stale events.
+- Only one billing provider may have an active secret on a deployment.
+- Not-yet-connected remains a WARN. Production mode fails closed on partial credentials,
+  test environments, missing mappings, or an unsupported provider selection.
+
+The selected provider reference under
+`.agents/skills/convex-structure/references/` defines its checkout, portal, webhook,
+lifecycle, and revocation details. Stripe's reference is `stripe-billing.md`.
+
+### Stripe adapter
 
 - The browser never names an amount or a price ID. It sends a **plan key** from
   `PLANS` in `convex/billing.ts`; price IDs live in Convex env (`STRIPE_PRICE_*`).

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -24,6 +24,11 @@ The catalog behind this table is
 instructions, automation steps, and revocation paths per provider, validated by
 schema, exercised by tests.
 
+Each entry also declares its capability and whether it is the default. Product briefs
+select one provider for billing, email, analytics, deployment, and tracking. A provider
+without an official command-line interface (CLI) or host Model Context Protocol (MCP)
+integration skips agent-tool authorization and starts at project provisioning.
+
 Hosts bring their own integrations too. Claude Code, Codex, and Cursor all support
 installable plugins and connectors for these same vendors, and the kit defers to them.
 A connection the host already provides is continued as-is. A host without one falls

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,10 +108,10 @@ one command:
 pnpm preflight --prod
 ```
 
-It fails while production still holds test Stripe keys. It fails while email is still
-in test mode without verification, while the seed backdoor flag exists, and while
-`src/lib/site.ts` still carries placeholders. Deploy is the terminal path on Netlify:
-`netlify init`, `netlify env:set` for the deploy key, then `netlify deploy --prod`.
+It fails when the selected billing provider uses its test environment. It also fails
+when email remains in test mode without verification, when the seed backdoor flag
+exists, or when `src/lib/site.ts` still carries placeholders. Deploy through Netlify
+with `netlify init`, `netlify env:set` for the deploy key, then `netlify deploy --prod`.
 The committed `netlify.toml` is the authoritative deployment description. If
 production misbehaves, roll back to the last green deploy first and diagnose locally
 second.

--- a/scripts/health.mjs
+++ b/scripts/health.mjs
@@ -13,6 +13,7 @@ const required = [
   ".agents/skills",
   ".agents/agents",
   ".agents/contracts/product-brief.schema.json",
+  ".agents/contracts/provider-selection.schema.json",
   ".agents/contracts/feature-contract.schema.json",
   ".agents/contracts/input-required.schema.json",
   ".agents/contracts/ui-plan.schema.json",

--- a/scripts/lib/billing-coherence.mjs
+++ b/scripts/lib/billing-coherence.mjs
@@ -1,95 +1,132 @@
-/**
- * Is billing COHERENT on a deployment — not merely "are some Stripe names present".
- *
- * Each key on its own looks fine; the damage lives in the combinations. A secret key
- * with no webhook secret takes the money and never grants the plan. A deployment
- * carrying prices and a webhook secret but no secret key reads as configured while
- * `billingIsLive()` is false, which silently leaves `workspaces.changePlan` open to the
- * browser — any owner can put their own workspace on a paid plan for nothing.
- *
- * Names only. This module never receives, inspects, or reports a secret VALUE.
- */
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadConnectionCatalog } from "./connections/catalog.mjs";
 
-export const BILLING_ENV = {
-  secret: "STRIPE_SECRET_KEY",
-  webhook: "STRIPE_WEBHOOK_SECRET",
-  pricePrefix: "STRIPE_PRICE_",
-  siteUrl: "SITE_URL",
-};
+export const BILLING_PROVIDER_ENV = "BILLING_PROVIDER";
 
-/**
- * @param {Iterable<string>} envNames names present on the deployment
- * @returns {{ status: "PASS"|"WARN"|"FAIL"|"CRITICAL", detail: string }}
- */
-export function inspectBillingCoherence(envNames) {
-  const names = new Set(envNames);
-  const has = (name) => names.has(name);
-  const prices = [...names].filter((name) => name.startsWith(BILLING_ENV.pricePrefix));
-  const anyStripe = [...names].some((name) => name.startsWith("STRIPE_"));
+const moduleRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
-  if (!anyStripe) {
-    return {
-      status: "WARN",
-      detail:
-        "no Stripe keys on this deployment — billing is off and plans switch directly, which is a normal pre-launch state. Run `pnpm onboard stripe --host <host>` when you want checkout.",
-    };
-  }
-
-  // Ordered by what each state costs. Taking money without granting the plan first.
-  if (has(BILLING_ENV.secret) && !has(BILLING_ENV.webhook)) {
-    return {
-      status: "CRITICAL",
-      detail:
-        "STRIPE_SECRET_KEY is set but STRIPE_WEBHOOK_SECRET is not — checkout completes, the webhook is rejected unsigned, and entitlement never arrives. The customer pays and gets nothing.",
-    };
-  }
-
-  // Below here nothing can take money — checkout throws before it reaches Stripe — so
-  // these are FAIL rather than CRITICAL. Severity tracks what it costs, not how broken
-  // it looks.
-  if (has(BILLING_ENV.secret) && prices.length === 0) {
-    return {
-      status: "FAIL",
-      detail:
-        "STRIPE_SECRET_KEY is set but no STRIPE_PRICE_* is — every checkout throws before it reaches Stripe. Run `pnpm stripe:provision`.",
-    };
-  }
-
-  if (has(BILLING_ENV.secret) && !has(BILLING_ENV.siteUrl)) {
-    return {
-      status: "FAIL",
-      detail:
-        "STRIPE_SECRET_KEY is set but SITE_URL is not — createCheckout throws, because Stripe needs a return URL that exists.",
-    };
-  }
-
-  // No secret key means checkout is unreachable, so this deployment behaves EXACTLY like
-  // one with no Stripe at all: nothing is charged, nothing leaks, no customer is touched.
-  // It is unfinished setup, not a broken build — and `pnpm stripe:provision` deliberately
-  // ends here, printing the one human step. Grading its own documented waypoint red would
-  // turn the engine's onboarding into a failing gate between two commands.
-  //
-  // The thing worth saying out loud is the DISCREPANCY: a deployment carrying prices and
-  // a webhook endpoint looks live to a person reading its env, and is not.
-  if (!has(BILLING_ENV.secret)) {
-    const orphans = [has(BILLING_ENV.webhook) ? BILLING_ENV.webhook : null, ...prices].filter(Boolean);
-    return {
-      status: "WARN",
-      detail:
-        `${orphans.join(", ")} present but STRIPE_SECRET_KEY is missing — billing is OFF despite looking configured. ` +
-        "createCheckout refuses, the settings screen offers direct plan switching, and entitlement is not webhook-owned yet. " +
-        "Finish it with `pnpm secret:set STRIPE_SECRET_KEY` (hidden input, straight into Convex env) — Stripe issues that key only in its dashboard, so it is the one step no CLI can automate. " +
-        `To stay pre-billing on purpose instead, drop the orphans: ${orphans.map((name) => `\`npx convex env remove ${name}\``).join(" ")}.`,
-    };
-  }
-
-  return { status: "PASS", detail: `secret, webhook and ${prices.length} price(s) all present` };
+function billingCatalog(catalogDirectory) {
+  const catalog = loadConnectionCatalog({ projectRoot: moduleRoot, catalogDirectory });
+  const providers = Object.fromEntries(
+    Object.entries(catalog.providers).filter(([, provider]) => provider.capability === "billing"),
+  );
+  return { providers, defaultProvider: catalog.defaults.billing };
 }
 
-/** Parse `convex env list` output into NAMES. Values are dropped here and never returned. */
+function result(status, detail, provider = null) {
+  return { status, detail, provider };
+}
+
+function namesForProvider(names, adapter) {
+  return [...names].filter((name) => adapter.ownedEnvPrefixes.some((prefix) => name.startsWith(prefix)));
+}
+
+function inspectSelectedProvider(names, id, provider) {
+  const adapter = provider.billing;
+  const owned = namesForProvider(names, adapter);
+  const has = (name) => names.has(name);
+
+  if (owned.length === 0) {
+    return result("WARN", `${provider.displayName} is selected but billing is not configured.`, id);
+  }
+  if (!has(adapter.secretEnv)) {
+    return result("WARN", `${provider.displayName} billing is off because ${adapter.secretEnv} is missing.`, id);
+  }
+  if (!has(adapter.webhookEnv)) {
+    return result(
+      "CRITICAL",
+      `${adapter.secretEnv} is set but ${adapter.webhookEnv} is missing. Checkout can take payment without granting entitlement.`,
+      id,
+    );
+  }
+  const missing = adapter.requiredEnv.filter((name) => !has(name));
+  if (missing.length > 0) return result("FAIL", `${provider.displayName} is missing ${missing.join(", ")}.`, id);
+
+  const mappings = [...names].filter((name) => name.startsWith(adapter.mappingEnvPrefix));
+  if (mappings.length === 0) {
+    return result("FAIL", `${provider.displayName} has no ${adapter.mappingEnvPrefix}* mapping.`, id);
+  }
+  return result("PASS", `${provider.displayName} billing configuration is complete.`, id);
+}
+
+/**
+ * Check billing completeness without reading secret values.
+ *
+ * Stripe remains the default when BILLING_PROVIDER is absent. Alternative providers
+ * must be selected explicitly by the caller.
+ */
+export function inspectBillingCoherence(envNames, { selectedProvider, catalogDirectory } = {}) {
+  const names = new Set(envNames ?? []);
+  const { providers, defaultProvider } = billingCatalog(catalogDirectory);
+  const selected = selectedProvider || defaultProvider;
+
+  if (!providers[selected]) {
+    return result("FAIL", `Unsupported billing provider "${selected}". Expected one of: ${Object.keys(providers).join(", ")}.`);
+  }
+
+  const configured = Object.entries(providers).filter(([, provider]) => namesForProvider(names, provider.billing).length > 0);
+  const active = configured.filter(([, provider]) => names.has(provider.billing.secretEnv));
+  if (active.length > 1) {
+    return result("FAIL", `Multiple billing provider secrets are configured: ${active.map(([, provider]) => provider.displayName).join(", ")}.`, selected);
+  }
+
+  const foreign = configured.filter(([id]) => id !== selected);
+  if (foreign.length > 0) {
+    return result(
+      "FAIL",
+      `${providers[selected].displayName} is selected, but environment names for ${foreign.map(([, provider]) => provider.displayName).join(", ")} are also present.`,
+      selected,
+    );
+  }
+
+  if (configured.length === 0) {
+    return result("WARN", "No billing keys are configured. Billing is off, which is valid before launch.", selected);
+  }
+  return inspectSelectedProvider(names, selected, providers[selected]);
+}
+
+function parseEnv(stdout) {
+  const values = new Map();
+  for (const line of (stdout ?? "").split("\n")) {
+    const match = /^\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    if (match) values.set(match[1], match[2]);
+  }
+  return values;
+}
+
+function productionCheckPasses(check, value) {
+  if (check.type === "equals") return value === check.value;
+  if (check.type === "matches") return new RegExp(check.pattern).test(value);
+  return false;
+}
+
+/** Validate production-only values without returning or printing any credential. */
+export function inspectProductionBillingEnvironment(stdout, { catalogDirectory } = {}) {
+  const values = parseEnv(stdout);
+  const { providers, defaultProvider } = billingCatalog(catalogDirectory);
+  const selected = values.get(BILLING_PROVIDER_ENV) || defaultProvider;
+  const coherence = inspectBillingCoherence(values.keys(), { selectedProvider: selected, catalogDirectory });
+  if (coherence.status !== "PASS") return coherence;
+
+  const provider = providers[selected];
+  const adapter = provider.billing;
+  const required = [adapter.secretEnv, adapter.webhookEnv, ...adapter.requiredEnv];
+  const empty = required.filter((name) => !(values.get(name) ?? "").trim());
+  const mappings = [...values.entries()].filter(
+    ([name, value]) => name.startsWith(adapter.mappingEnvPrefix) && value.trim().length > 0,
+  );
+  if (empty.length > 0 || mappings.length === 0) {
+    return result("FAIL", `${provider.displayName} production billing has empty required values or mappings.`, selected);
+  }
+
+  for (const check of adapter.productionChecks) {
+    if (!productionCheckPasses(check, values.get(check.env) ?? "")) return result("FAIL", check.message, selected);
+  }
+  return result("PASS", `${provider.displayName} production billing is live.`, selected);
+}
+
+/** Parse `convex env list` output into names. Values are discarded. */
 export function envNamesFrom(stdout) {
-  return (stdout ?? "")
-    .split("\n")
-    .map((line) => (/^\s*([A-Za-z_][A-Za-z0-9_]*)=/.exec(line) ?? [])[1])
-    .filter(Boolean);
+  return [...parseEnv(stdout).keys()];
 }

--- a/scripts/lib/billing-coherence.test.mjs
+++ b/scripts/lib/billing-coherence.test.mjs
@@ -1,81 +1,140 @@
 // @vitest-environment node
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
-import { envNamesFrom, inspectBillingCoherence } from "./billing-coherence.mjs";
+import { envNamesFrom, inspectBillingCoherence, inspectProductionBillingEnvironment } from "./billing-coherence.mjs";
 
-/**
- * The billing states a deployment can be in, and what each one costs.
- *
- * These combinations are why the check exists: every name below is individually valid
- * and the deployment is broken anyway. The severities are asserted rather than assumed,
- * because the ordering IS the rule — a state that can take money without granting a plan
- * has to outrank one where checkout simply throws.
- */
-const PRICE = "STRIPE_PRICE_PRO";
-const SECRET = "STRIPE_SECRET_KEY";
-const WEBHOOK = "STRIPE_WEBHOOK_SECRET";
-const SITE = "SITE_URL";
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const connectionDirectory = join(repositoryRoot, ".agents", "connections");
+const STRIPE_COMPLETE = ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET", "STRIPE_PRICE_PRO", "SITE_URL"];
+
+function alternativeBillingCatalog(t) {
+  const root = mkdtempSync(join(tmpdir(), "billing-adapter-"));
+  const directory = join(root, "connections");
+  mkdirSync(directory, { recursive: true });
+  t.onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+
+  const providers = JSON.parse(readFileSync(join(connectionDirectory, "providers.json"), "utf8"));
+  providers.providers.fixturepay = structuredClone(providers.providers.stripe);
+  Object.assign(providers.providers.fixturepay, {
+    displayName: "Fixture Pay",
+    defaultForCapability: false,
+    billing: {
+      ownedEnvPrefixes: ["FIXTURE_PAY_"],
+      secretEnv: "FIXTURE_PAY_SECRET",
+      webhookEnv: "FIXTURE_PAY_WEBHOOK",
+      requiredEnv: ["SITE_URL", "FIXTURE_PAY_MODE"],
+      mappingEnvPrefix: "FIXTURE_PAY_PLAN_",
+      productionChecks: [
+        {
+          type: "equals",
+          env: "FIXTURE_PAY_MODE",
+          value: "live",
+          message: "Fixture Pay requires live mode in production.",
+        },
+      ],
+    },
+  });
+  writeFileSync(join(directory, "providers.json"), JSON.stringify(providers), "utf8");
+  writeFileSync(join(directory, "hosts.json"), readFileSync(join(connectionDirectory, "hosts.json")), "utf8");
+  return directory;
+}
 
 describe("billing coherence", () => {
-  test("no Stripe at all is a normal pre-launch state, not a failure", () => {
-    // AGENTS.md: not-yet-connected is a WARN, never an error.
-    const result = inspectBillingCoherence([SITE, "BETTER_AUTH_SECRET"]);
-    expect(result.status).toBe("WARN");
-    expect(result.detail).toMatch(/billing is off/i);
+  test("keeps Stripe as the default and treats no keys as pre-launch", () => {
+    expect(inspectBillingCoherence(["SITE_URL"])).toEqual({
+      status: "WARN",
+      detail: "No billing keys are configured. Billing is off, which is valid before launch.",
+      provider: "stripe",
+    });
   });
 
-  test("a complete configuration passes", () => {
-    expect(inspectBillingCoherence([SECRET, WEBHOOK, PRICE, SITE]).status).toBe("PASS");
+  test("accepts a complete selected provider", () => {
+    expect(inspectBillingCoherence(STRIPE_COMPLETE).status).toBe("PASS");
   });
 
-  test("secret key without a webhook secret is CRITICAL — the customer pays and gets nothing", () => {
-    // The only state here where money moves and no entitlement follows.
-    const result = inspectBillingCoherence([SECRET, PRICE, SITE]);
+  test("reports the money-losing partial configuration as critical", () => {
+    const result = inspectBillingCoherence(["STRIPE_SECRET_KEY", "STRIPE_PRICE_PRO", "SITE_URL"]);
     expect(result.status).toBe("CRITICAL");
-    expect(result.detail).toMatch(/pays and gets nothing/i);
+    expect(result.detail).toMatch(/take payment without granting entitlement/);
   });
 
-  test("secret key without a price fails, but is not CRITICAL — checkout throws first", () => {
-    expect(inspectBillingCoherence([SECRET, WEBHOOK, SITE]).status).toBe("FAIL");
+  test("dispatches an alternative adapter without editing coherence code", (t) => {
+    const catalogDirectory = alternativeBillingCatalog(t);
+    const names = ["FIXTURE_PAY_SECRET", "FIXTURE_PAY_WEBHOOK", "FIXTURE_PAY_MODE", "FIXTURE_PAY_PLAN_PRO", "SITE_URL"];
+    expect(inspectBillingCoherence(names, { selectedProvider: "fixturepay", catalogDirectory }).status).toBe("PASS");
   });
 
-  test("secret key without SITE_URL fails — Stripe needs a return URL", () => {
-    expect(inspectBillingCoherence([SECRET, WEBHOOK, PRICE]).status).toBe("FAIL");
+  test("rejects foreign provider names and multiple active secrets", (t) => {
+    const catalogDirectory = alternativeBillingCatalog(t);
+    const names = [...STRIPE_COMPLETE, "FIXTURE_PAY_SECRET", "FIXTURE_PAY_WEBHOOK", "FIXTURE_PAY_PLAN_PRO"];
+    const result = inspectBillingCoherence(names, { selectedProvider: "stripe", catalogDirectory });
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toMatch(/Multiple billing provider secrets/);
   });
 
-  test("prices and a webhook secret with no key warns rather than fails", () => {
-    // Unfinished setup, not a broken build: with no secret key checkout is unreachable,
-    // so the deployment behaves exactly like one with no Stripe at all. `stripe:provision`
-    // ends in this state by design, and red-gating it would break the engine's own
-    // onboarding between two commands. The discrepancy still has to be said out loud.
-    const result = inspectBillingCoherence([WEBHOOK, PRICE, SITE]);
-    expect(result.status).toBe("WARN");
-    expect(result.detail).toMatch(/billing is OFF despite looking configured/);
-    expect(result.detail).toMatch(/pnpm secret:set STRIPE_SECRET_KEY/);
-  });
-
-  test("a reachable checkout that cannot pay out is the line between WARN and red", () => {
-    // The severity rule, stated as a pair: the ONLY difference between these two is
-    // whether a customer's card can be charged.
-    expect(inspectBillingCoherence([WEBHOOK, PRICE, SITE]).status).toBe("WARN");
-    expect(inspectBillingCoherence([SECRET, PRICE, SITE]).status).toBe("CRITICAL");
-  });
-
-  test("the money-losing state wins when several things are wrong at once", () => {
-    // Secret set, nothing else. Webhook outranks price: it is the costlier failure.
-    expect(inspectBillingCoherence([SECRET]).status).toBe("CRITICAL");
+  test("rejects an unsupported provider with an actionable list", () => {
+    const result = inspectBillingCoherence(STRIPE_COMPLETE, { selectedProvider: "unknown" });
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toMatch(/Expected one of: stripe/);
   });
 });
 
-describe("env parsing", () => {
-  test("keeps names and drops every value", () => {
-    const names = envNamesFrom("STRIPE_SECRET_KEY=sk_test_dont_leak_me\nSITE_URL=http://x\n\n");
-    expect(names).toEqual(["STRIPE_SECRET_KEY", "SITE_URL"]);
-    expect(names.join()).not.toMatch(/sk_test/);
+describe("production billing", () => {
+  test("preserves Stripe live-mode behavior when selection is omitted", () => {
+    const env = [
+      "STRIPE_SECRET_KEY=sk_live_private",
+      "STRIPE_WEBHOOK_SECRET=whsec_private",
+      "STRIPE_PRICE_PRO=price_private",
+      "SITE_URL=https://example.com",
+      "",
+    ].join("\n");
+    expect(inspectProductionBillingEnvironment(env)).toEqual({
+      status: "PASS",
+      detail: "Stripe production billing is live.",
+      provider: "stripe",
+    });
   });
 
-  test("survives an empty or noisy stream", () => {
-    expect(envNamesFrom("")).toEqual([]);
-    expect(envNamesFrom(undefined)).toEqual([]);
-    expect(envNamesFrom("not an assignment line\n")).toEqual([]);
+  test("rejects Stripe test keys without exposing their value", () => {
+    const env = [
+      "STRIPE_SECRET_KEY=sk_test_do_not_print",
+      "STRIPE_WEBHOOK_SECRET=whsec_do_not_print",
+      "STRIPE_PRICE_PRO=price_do_not_print",
+      "SITE_URL=https://example.com",
+      "",
+    ].join("\n");
+    const result = inspectProductionBillingEnvironment(env);
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toMatch(/live secret key/);
+    expect(JSON.stringify(result)).not.toMatch(/do_not_print/);
+  });
+
+  test("runs provider-owned production checks for alternatives", (t) => {
+    const catalogDirectory = alternativeBillingCatalog(t);
+    const base = [
+      "BILLING_PROVIDER=fixturepay",
+      "FIXTURE_PAY_SECRET=private",
+      "FIXTURE_PAY_WEBHOOK=private",
+      "FIXTURE_PAY_PLAN_PRO=private",
+      "SITE_URL=https://example.com",
+    ];
+    expect(inspectProductionBillingEnvironment([...base, "FIXTURE_PAY_MODE=test"].join("\n"), { catalogDirectory }).status).toBe("FAIL");
+    expect(inspectProductionBillingEnvironment([...base, "FIXTURE_PAY_MODE=live"].join("\n"), { catalogDirectory }).status).toBe("PASS");
+  });
+
+  test("rejects empty required values", () => {
+    const env = "STRIPE_SECRET_KEY=\nSTRIPE_WEBHOOK_SECRET=\nSTRIPE_PRICE_PRO=\nSITE_URL=\n";
+    expect(inspectProductionBillingEnvironment(env).status).toBe("FAIL");
+  });
+});
+
+describe("environment parsing", () => {
+  test("keeps names and discards values", () => {
+    const names = envNamesFrom("STRIPE_SECRET_KEY=sk_test_dont_leak_me\nSITE_URL=http://x\n");
+    expect(names).toEqual(["STRIPE_SECRET_KEY", "SITE_URL"]);
+    expect(names.join()).not.toMatch(/dont_leak_me/);
   });
 });

--- a/scripts/lib/connections/catalog.mjs
+++ b/scripts/lib/connections/catalog.mjs
@@ -6,6 +6,8 @@ const PLACEHOLDER = /\{([a-z][a-z0-9-]*)\}/g;
 const PROBE_TYPES = new Set(["any_file_exists", "env_file_key", "file_contains", "file_exists", "home_file_exists", "mcp_server"]);
 const AUTH_FLOWS = new Set(["cli_browser_login", "remote_oauth"]);
 const VERIFICATION_POLICIES = new Set(["machine", "probe_and_attestation"]);
+const CAPABILITIES = new Set(["analytics", "backend", "billing", "deployment", "email", "repository", "tracking"]);
+const PRODUCTION_CHECK_TYPES = new Set(["equals", "matches"]);
 
 function readJson(path) {
   try {
@@ -99,6 +101,44 @@ function validateAutomation(automation, owner) {
   validateDecision(automation.decision, `${owner}.automation`);
 }
 
+function validateBillingAdapter(adapter, owner) {
+  assert(adapter && typeof adapter === "object", `${owner}.billing must be an object`);
+  assert(
+    Array.isArray(adapter.ownedEnvPrefixes) &&
+      adapter.ownedEnvPrefixes.length > 0 &&
+      adapter.ownedEnvPrefixes.every((prefix) => typeof prefix === "string" && /^[A-Z][A-Z0-9_]*_$/.test(prefix)),
+    `${owner}.billing needs uppercase ownedEnvPrefixes`,
+  );
+  for (const key of ["secretEnv", "webhookEnv"]) {
+    assert(typeof adapter[key] === "string" && /^[A-Z][A-Z0-9_]*$/.test(adapter[key]), `${owner}.billing.${key} must be an env name`);
+  }
+  assert(
+    Array.isArray(adapter.requiredEnv) && adapter.requiredEnv.every((name) => typeof name === "string" && /^[A-Z][A-Z0-9_]*$/.test(name)),
+    `${owner}.billing.requiredEnv must contain env names`,
+  );
+  assert(
+    typeof adapter.mappingEnvPrefix === "string" && /^[A-Z][A-Z0-9_]*_$/.test(adapter.mappingEnvPrefix),
+    `${owner}.billing.mappingEnvPrefix must be an uppercase env prefix`,
+  );
+  assert(Array.isArray(adapter.productionChecks) && adapter.productionChecks.length > 0, `${owner}.billing needs productionChecks`);
+  for (const [index, check] of adapter.productionChecks.entries()) {
+    const checkOwner = `${owner}.billing.productionChecks[${index}]`;
+    assert(check && typeof check === "object", `${checkOwner} must be an object`);
+    assert(PRODUCTION_CHECK_TYPES.has(check.type), `${checkOwner} uses unsupported type ${check.type}`);
+    assert(typeof check.env === "string" && /^[A-Z][A-Z0-9_]*$/.test(check.env), `${checkOwner}.env must be an env name`);
+    assert(typeof check.message === "string" && check.message.length > 0, `${checkOwner} needs a message`);
+    if (check.type === "equals") assert(typeof check.value === "string" && check.value.length > 0, `${checkOwner} needs value`);
+    if (check.type === "matches") {
+      assert(typeof check.pattern === "string" && check.pattern.length > 0, `${checkOwner} needs pattern`);
+      try {
+        new RegExp(check.pattern);
+      } catch {
+        assert(false, `${checkOwner} has an invalid pattern`);
+      }
+    }
+  }
+}
+
 export function loadConnectionCatalog({ projectRoot, catalogDirectory } = {}) {
   const root = resolve(projectRoot ?? process.cwd());
   const directory = resolve(catalogDirectory ?? join(root, ".agents", "connections"));
@@ -110,19 +150,33 @@ export function loadConnectionCatalog({ projectRoot, catalogDirectory } = {}) {
   assert(providerDocument.providers && typeof providerDocument.providers === "object", "providers.json needs providers");
   assert(hostDocument.hosts && typeof hostDocument.hosts === "object", "hosts.json needs hosts");
 
+  const defaults = new Map();
   for (const [id, provider] of Object.entries(providerDocument.providers)) {
     assert(IDENTIFIER.test(id), `provider id ${id} must be kebab-case`);
     assert(typeof provider.displayName === "string" && provider.displayName.length > 0, `${id} needs displayName`);
+    assert(CAPABILITIES.has(provider.capability), `${id} needs a supported capability`);
+    assert(typeof provider.defaultForCapability === "boolean", `${id} must declare defaultForCapability`);
+    if (provider.defaultForCapability) {
+      assert(!defaults.has(provider.capability), `${id} duplicates the ${provider.capability} default ${defaults.get(provider.capability)}`);
+      defaults.set(provider.capability, id);
+    }
     assert(Number.isInteger(provider.actionTtlMinutes) && provider.actionTtlMinutes > 0, `${id} needs a positive actionTtlMinutes`);
     assert(Number.isInteger(provider.maxVerificationAttempts) && provider.maxVerificationAttempts > 0, `${id} needs positive maxVerificationAttempts`);
-    assert(AUTH_FLOWS.has(provider.agentTool?.authFlow), `${id} has an unsupported agent-tool auth flow`);
-    assert(IDENTIFIER.test(provider.agentTool?.mcpServer ?? ""), `${id} needs an MCP server id`);
-    assert(
-      Array.isArray(provider.agentTool?.instructions) && provider.agentTool.instructions.length > 0 && provider.agentTool.instructions.every((step) => typeof step === "string"),
-      `${id} needs agent-tool instructions`,
-    );
-    validateProbe(provider.agentTool.configurationProbe, `${id}.agentTool`);
-    validateAutomation(provider.agentTool.automation, `${id}.agentTool`);
+    if (provider.agentTool !== undefined) {
+      assert(provider.agentTool && typeof provider.agentTool === "object", `${id}.agentTool must be an object when declared`);
+      assert(AUTH_FLOWS.has(provider.agentTool.authFlow), `${id} has an unsupported agent-tool auth flow`);
+      assert(IDENTIFIER.test(provider.agentTool.mcpServer ?? ""), `${id} needs an MCP server id`);
+      assert(
+        Array.isArray(provider.agentTool.instructions) &&
+          provider.agentTool.instructions.length > 0 &&
+          provider.agentTool.instructions.every((step) => typeof step === "string"),
+        `${id} needs agent-tool instructions`,
+      );
+      validateProbe(provider.agentTool.configurationProbe, `${id}.agentTool`);
+      validateAutomation(provider.agentTool.automation, `${id}.agentTool`);
+    }
+    if (provider.capability === "billing") validateBillingAdapter(provider.billing, id);
+    else assert(provider.billing === undefined, `${id} declares billing configuration for ${provider.capability}`);
     validateAutomation(provider.projectProvisioning?.automation, `${id}.projectProvisioning`);
     validateSteps(provider.revocation, `${id}.revocation`);
 
@@ -138,6 +192,8 @@ export function loadConnectionCatalog({ projectRoot, catalogDirectory } = {}) {
     for (const probe of verification.probes) validateProbe(probe, `${id}.projectProvisioning`);
   }
 
+  for (const capability of CAPABILITIES) assert(defaults.has(capability), `capability ${capability} needs exactly one default provider`);
+
   for (const [id, host] of Object.entries(hostDocument.hosts)) {
     assert(IDENTIFIER.test(id), `host id ${id} must be kebab-case`);
     assert(typeof host.displayName === "string" && host.displayName.length > 0, `${id} needs displayName`);
@@ -150,6 +206,7 @@ export function loadConnectionCatalog({ projectRoot, catalogDirectory } = {}) {
   return {
     schemaVersion: 1,
     providers: providerDocument.providers,
+    defaults: Object.fromEntries(defaults),
     hosts: hostDocument.hosts,
   };
 }

--- a/scripts/lib/connections/service.mjs
+++ b/scripts/lib/connections/service.mjs
@@ -110,6 +110,7 @@ export function createConnectionService({
   }
 
   function agentToolConfiguration(provider) {
+    if (!provider.agentTool) return null;
     return runConnectionProbe(provider.agentTool.configurationProbe, probeContext);
   }
 
@@ -123,6 +124,7 @@ export function createConnectionService({
 
   function agentToolInput(action, at) {
     const provider = getProvider(action.provider);
+    if (!provider.agentTool) throw new Error(`${action.provider} does not require agent-tool authorization`);
     const host = getHost(action.host);
     const configuration = agentToolConfiguration(provider);
     const hostInstruction = host.authInstructions[provider.agentTool.authFlow].replaceAll("<server>", provider.agentTool.mcpServer);
@@ -204,12 +206,18 @@ export function createConnectionService({
           policy: getProvider(action.provider).projectProvisioning.verification.policy,
           project: verification ?? projectVerification(getProvider(action.provider)),
           agentTool: {
-            passed: Boolean(action.agentToolAttestedAt) || action.history.some((entry) => entry.event === "verified_preexisting"),
-            basis: action.agentToolAttestedAt
-              ? "resume_after_user_consent_and_host_read_only_probe"
-              : action.history.some((entry) => entry.event === "verified_preexisting")
-                ? "preexisting_local_configuration"
-                : "resume_after_user_consent_and_host_read_only_probe",
+            required: Boolean(getProvider(action.provider).agentTool),
+            passed:
+              !getProvider(action.provider).agentTool ||
+              Boolean(action.agentToolAttestedAt) ||
+              action.history.some((entry) => entry.event === "verified_preexisting"),
+            basis: !getProvider(action.provider).agentTool
+              ? "not_required"
+              : action.agentToolAttestedAt
+                ? "resume_after_user_consent_and_host_read_only_probe"
+                : action.history.some((entry) => entry.event === "verified_preexisting")
+                  ? "preexisting_local_configuration"
+                  : "resume_after_user_consent_and_host_read_only_probe",
           },
         },
       };
@@ -320,7 +328,7 @@ export function createConnectionService({
         const preexistingConfiguration = agentToolConfiguration(provider);
         const preexistingVerification = projectVerification(provider);
         if (
-          preexistingConfiguration.passed &&
+          (!provider.agentTool || preexistingConfiguration.passed) &&
           provider.projectProvisioning.verification.policy === "machine" &&
           preexistingVerification.passed
         ) {
@@ -336,7 +344,7 @@ export function createConnectionService({
             updatedAt: bornAt,
             expiresAt: timestamp(new Date(at.getTime() + provider.actionTtlMinutes * 60_000)),
             verificationAttempts: 0,
-            completedPhases: ["agent_tool_authorization", "project_provisioning"],
+            completedPhases: provider.agentTool ? ["agent_tool_authorization", "project_provisioning"] : ["project_provisioning"],
             agentToolAttestedAt: null,
             projectAttestedAt: null,
             history: [
@@ -355,7 +363,7 @@ export function createConnectionService({
           provider: providerId,
           host: hostId,
           state: "waiting_for_user",
-          phase: "agent_tool_authorization",
+          phase: provider.agentTool ? "agent_tool_authorization" : "project_provisioning",
           createdAt,
           updatedAt: createdAt,
           expiresAt: timestamp(new Date(at.getTime() + provider.actionTtlMinutes * 60_000)),
@@ -366,7 +374,7 @@ export function createConnectionService({
           history: [{ event: "created", at: createdAt }],
         };
         store.write(action);
-        return agentToolInput(action, at);
+        return provider.agentTool ? agentToolInput(action, at) : projectInput(action, at, preexistingVerification);
       });
     },
 

--- a/scripts/lib/connections/service.test.mjs
+++ b/scripts/lib/connections/service.test.mjs
@@ -315,6 +315,62 @@ test("catalog placeholders fail closed when a command uses an undeclared token",
   );
 });
 
+test("a project-only provider skips fictional MCP authorization", (t) => {
+  const temporaryRoot = mkdtempSync(join(tmpdir(), "agent-connections-project-only-"));
+  t.onTestFinished(() => rmSync(temporaryRoot, { recursive: true, force: true }));
+  const customCatalog = join(temporaryRoot, "connections");
+  const projectRoot = join(temporaryRoot, "project");
+  const stateDirectory = join(temporaryRoot, "state");
+  mkdirSync(customCatalog, { recursive: true });
+  mkdirSync(projectRoot, { recursive: true });
+
+  const providers = JSON.parse(readFileSync(join(catalogDirectory, "providers.json"), "utf8"));
+  providers.providers.fixturepay = structuredClone(providers.providers.stripe);
+  providers.providers.fixturepay.displayName = "Fixture Pay";
+  providers.providers.fixturepay.defaultForCapability = false;
+  delete providers.providers.fixturepay.agentTool;
+  providers.providers.fixturepay.billing = {
+    ownedEnvPrefixes: ["FIXTURE_PAY_"],
+    secretEnv: "FIXTURE_PAY_SECRET",
+    webhookEnv: "FIXTURE_PAY_WEBHOOK",
+    requiredEnv: ["SITE_URL"],
+    mappingEnvPrefix: "FIXTURE_PAY_PLAN_",
+    productionChecks: [
+      {
+        type: "equals",
+        env: "FIXTURE_PAY_MODE",
+        value: "live",
+        message: "Fixture Pay requires live mode.",
+      },
+    ],
+  };
+  providers.providers.fixturepay.projectProvisioning.verification.probes = [
+    {
+      id: "fixture-seam",
+      label: "Fixture billing seam exists",
+      type: "file_contains",
+      file: "convex/billing.ts",
+      text: "fixturepay",
+      required: true,
+    },
+  ];
+  writeFileSync(join(customCatalog, "providers.json"), JSON.stringify(providers), "utf8");
+  writeFileSync(join(customCatalog, "hosts.json"), readFileSync(join(catalogDirectory, "hosts.json")), "utf8");
+
+  const service = createConnectionService({ projectRoot, catalogDirectory: customCatalog, stateDirectory });
+  const started = service.begin("fixturepay", "codex");
+  assert.equal(started.type, "input_required");
+  assert.equal(started.action.phase, "project_provisioning");
+  assert.equal(started.inputRequired.kind, "project_provisioning");
+  assert.doesNotMatch(JSON.stringify(started), /read-only provider call|remote_oauth/);
+
+  write(projectRoot, "convex/billing.ts", 'const adapter = "fixturepay";');
+  const ready = service.resume(started.action.actionId);
+  assert.equal(ready.type, "connection_ready");
+  assert.equal(ready.verification.agentTool.required, false);
+  assert.equal(ready.verification.agentTool.basis, "not_required");
+});
+
 test("active actions expire and a new begin creates a fresh receipt", (t) => {
   const { service, advance } = fixture(t);
   const first = service.begin("netlify", "codex");

--- a/scripts/lib/provider-selection.mjs
+++ b/scripts/lib/provider-selection.mjs
@@ -1,0 +1,35 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadConnectionCatalog } from "./connections/catalog.mjs";
+
+export const PRODUCT_PROVIDER_CAPABILITIES = ["billing", "email", "analytics", "deployment", "tracking"];
+
+const moduleRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+export function resolveProviderSelection(selection, { catalogDirectory } = {}) {
+  if (!selection || typeof selection !== "object" || Array.isArray(selection)) {
+    throw new Error("providerSelection must be an object");
+  }
+
+  const unexpected = Object.keys(selection).filter((capability) => !PRODUCT_PROVIDER_CAPABILITIES.includes(capability));
+  if (unexpected.length > 0) throw new Error(`providerSelection has unsupported capabilities: ${unexpected.join(", ")}`);
+
+  const catalog = loadConnectionCatalog({ projectRoot: moduleRoot, catalogDirectory });
+  const resolved = {};
+  for (const capability of PRODUCT_PROVIDER_CAPABILITIES) {
+    const requested = selection[capability] === undefined ? catalog.defaults[capability] : selection[capability];
+    if (requested === null && capability === "tracking") {
+      resolved[capability] = null;
+      continue;
+    }
+    const provider = catalog.providers[requested];
+    if (!provider || provider.capability !== capability) {
+      const supported = Object.entries(catalog.providers)
+        .filter(([, candidate]) => candidate.capability === capability)
+        .map(([id]) => id);
+      throw new Error(`Unsupported ${capability} provider "${requested}". Expected one of: ${supported.join(", ")}`);
+    }
+    resolved[capability] = requested;
+  }
+  return resolved;
+}

--- a/scripts/lib/provider-selection.test.mjs
+++ b/scripts/lib/provider-selection.test.mjs
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+import { PRODUCT_PROVIDER_CAPABILITIES, resolveProviderSelection } from "./provider-selection.mjs";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const connectionDirectory = join(repositoryRoot, ".agents", "connections");
+
+function catalogWithAlternatives(t) {
+  const root = mkdtempSync(join(tmpdir(), "provider-selection-"));
+  const directory = join(root, "connections");
+  mkdirSync(directory, { recursive: true });
+  t.onTestFinished(() => rmSync(root, { recursive: true, force: true }));
+
+  const document = JSON.parse(readFileSync(join(connectionDirectory, "providers.json"), "utf8"));
+  const alternatives = {};
+  for (const capability of PRODUCT_PROVIDER_CAPABILITIES) {
+    const [sourceId, source] = Object.entries(document.providers).find(
+      ([, provider]) => provider.capability === capability && provider.defaultForCapability,
+    );
+    const id = `fixture-${capability}`;
+    const provider = structuredClone(source);
+    provider.displayName = `Fixture ${capability}`;
+    provider.defaultForCapability = false;
+    if (capability === "billing") {
+      provider.billing = {
+        ownedEnvPrefixes: ["FIXTURE_BILLING_"],
+        secretEnv: "FIXTURE_BILLING_SECRET",
+        webhookEnv: "FIXTURE_BILLING_WEBHOOK",
+        requiredEnv: ["SITE_URL"],
+        mappingEnvPrefix: "FIXTURE_BILLING_PLAN_",
+        productionChecks: [
+          {
+            type: "equals",
+            env: "FIXTURE_BILLING_MODE",
+            value: "live",
+            message: "Fixture billing requires live mode.",
+          },
+        ],
+      };
+    }
+    document.providers[id] = provider;
+    alternatives[capability] = id;
+    expect(sourceId).toBeTruthy();
+  }
+  writeFileSync(join(directory, "providers.json"), JSON.stringify(document), "utf8");
+  writeFileSync(join(directory, "hosts.json"), readFileSync(join(connectionDirectory, "hosts.json")), "utf8");
+  return { directory, alternatives };
+}
+
+test("provider selection resolves the declared defaults", () => {
+  expect(resolveProviderSelection({})).toEqual({
+    billing: "stripe",
+    email: "resend",
+    analytics: "posthog",
+    deployment: "netlify",
+    tracking: "linear",
+  });
+});
+
+test("every capability accepts an alternative through the same contract", (t) => {
+  const { directory, alternatives } = catalogWithAlternatives(t);
+  expect(resolveProviderSelection(alternatives, { catalogDirectory: directory })).toEqual(alternatives);
+});
+
+test("tracking may be disabled without weakening the other selections", () => {
+  expect(resolveProviderSelection({ tracking: null })).toEqual({
+    billing: "stripe",
+    email: "resend",
+    analytics: "posthog",
+    deployment: "netlify",
+    tracking: null,
+  });
+});
+
+test("a provider cannot be selected for the wrong capability", () => {
+  expect(() => resolveProviderSelection({ billing: "resend" })).toThrow(/Unsupported billing provider/);
+});
+
+test("the product brief requires the versioned provider selection", () => {
+  const schema = JSON.parse(readFileSync(join(repositoryRoot, ".agents", "contracts", "product-brief.schema.json"), "utf8"));
+  expect(schema.properties.schemaVersion.const).toBe(2);
+  expect(schema.required).toContain("providerSelection");
+  expect(schema.properties.providerSelection.$ref).toBe("provider-selection.schema.json");
+});

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -3,8 +3,8 @@
  * Production preflight — the go-live gate.
  *
  * `pnpm health` asks "is development sound?". This asks a different question:
- * "is PRODUCTION real?" — live Stripe keys in the prod deployment, email leaving
- * testMode with verification on, no test-seed backdoor, real URLs. Run it before the
+ * "is PRODUCTION real?" — selected-provider production billing, email leaving testMode
+ * with verification on, no test-seed backdoor, real URLs. Run it before the
  * first real deploy and before every launch after config changes.
  *
  *   pnpm preflight            checks that need no deployment (code + files)
@@ -18,7 +18,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { envNamesFrom, inspectBillingCoherence } from "./lib/billing-coherence.mjs";
+import { inspectProductionBillingEnvironment } from "./lib/billing-coherence.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const read = (p) => (existsSync(join(root, p)) ? readFileSync(join(root, p), "utf8") : "");
@@ -62,12 +62,20 @@ if (!authSrc) {
 
 const siteSrc = read("src/lib/site.ts");
 const placeholder = /My App|what it does, in one line|someone would actually read/.test(siteSrc);
-add("site identity is real", placeholder ? "FAIL" : "PASS", placeholder ? "src/lib/site.ts still holds the scaffold placeholders — this text is your <title>, OG card and llms.txt" : "");
+add(
+  "site identity is real",
+  siteSrc ? (placeholder ? "FAIL" : "PASS") : "SKIP",
+  siteSrc ? (placeholder ? "src/lib/site.ts still holds scaffold placeholders used by metadata" : "") : "no product site exists in this tool repository",
+);
 
 // The public URL is env-driven per environment; the prod value is audited in the
 // --prod section below. Locally, the blueprint is the thing that must be intact:
 const blueprint = read("netlify.toml");
-add("deploy blueprint intact", /convex deploy/.test(blueprint) ? "PASS" : "FAIL", /convex deploy/.test(blueprint) ? "" : "netlify.toml missing or its build command no longer runs `npx convex deploy` — frontend would ship against a stale backend");
+add(
+  "deploy blueprint intact",
+  blueprint ? (/convex deploy/.test(blueprint) ? "PASS" : "FAIL") : "SKIP",
+  blueprint ? (/convex deploy/.test(blueprint) ? "" : "netlify.toml no longer deploys Convex before the frontend build") : "no downstream product deployment exists in this tool repository",
+);
 
 /* ---------- the CSP that actually ships ---------- */
 
@@ -90,8 +98,12 @@ add(
 /* ---------- dev-side leaks that become launch incidents ---------- */
 
 const envLocal = read(".env.local");
-const localLiveKey = /\b(sk_live_|rk_live_)/.test(envLocal);
-add("no live Stripe key on this machine", localLiveKey ? "FAIL" : "PASS", localLiveKey ? "live keys belong in the PROD Convex deployment env only (rule R7)" : "");
+const localBillingSecret = /\b(sk_live_|rk_live_)|^(POLAR_ACCESS_TOKEN|LEMON_SQUEEZY_API_KEY)=/m.test(envLocal);
+add(
+  "no production billing secret on this machine",
+  localBillingSecret ? "FAIL" : "PASS",
+  localBillingSecret ? "production billing secrets belong in the production Convex deployment environment" : "",
+);
 
 /* ---------- the full local gate ---------- */
 
@@ -113,11 +125,8 @@ if (withProd) {
     const has = (k) => new RegExp(`^${k}=`, "m").test(env);
     const val = (k) => (env.match(new RegExp(`^${k}=(.*)$`, "m")) ?? [])[1] ?? "";
 
-    add("prod Stripe key is LIVE", /^(sk|rk)_live_/.test(val("STRIPE_SECRET_KEY")) ? "PASS" : "FAIL", "prod has a test key (or none) — production would take test payments. Set the live key with `npx convex env set --prod STRIPE_SECRET_KEY ...`");
-    // The individual keys are audited above; this states the COMBINATIONS, from the same
-    // module `pnpm health` uses, so the rule has one home rather than two drifting copies.
-    const coherence = inspectBillingCoherence(envNamesFrom(env));
-    add("prod billing coherence", coherence.status === "PASS" ? "PASS" : "FAIL", coherence.status === "PASS" ? "" : coherence.detail);
+    const billing = inspectProductionBillingEnvironment(env);
+    add("prod billing provider is live", billing.status === "PASS" ? "PASS" : "FAIL", billing.status === "PASS" ? "" : billing.detail);
     add("prod Resend key set", has("RESEND_API_KEY") ? "PASS" : "FAIL", "production sends no email without it");
     add("prod EMAIL_FROM on a verified domain", has("EMAIL_FROM") && !/resend\.dev/.test(val("EMAIL_FROM")) ? "PASS" : "FAIL", "EMAIL_FROM missing or still the onboarding fallback — verify a sending domain and set it");
     add("prod SITE_URL is https and not localhost", /^https:\/\//.test(val("SITE_URL")) && !/localhost/.test(val("SITE_URL")) ? "PASS" : "FAIL", "auth callbacks and emails will point at the wrong host");


### PR DESCRIPTION
Closes #17.

## What changed

- adds versioned product-brief provider selection for billing, email, analytics, deployment, and tracking
- declares provider capabilities and exactly one default per capability in the connection catalog
- allows providers without an official CLI or MCP connection to begin at project provisioning
- dispatches billing coherence and production checks from provider-owned catalog data
- preserves Stripe as the default when `BILLING_PROVIDER` is absent
- adds alternative-provider fixtures for every capability and fail-closed billing preflight coverage

## Why

Polar and Lemon Squeezy both need the same selected-provider, connection, and preflight contract. Without this foundation, each provider adds conflicting branches to shared files and can claim an MCP authorization that does not exist.

## Verification

- `pnpm exec vitest run scripts/lib/billing-coherence.test.mjs scripts/lib/provider-selection.test.mjs scripts/lib/connections/service.test.mjs`
- `pnpm verify:full`
- `pnpm preflight`
- `git diff --check`
