### PR TITLE
feat(mcp): add native project-scoped Agentic Ship MCP server (#14)

### DIFF
--- a/.agents/skills/convex-structure/references/agentic-ship-mcp.md
+++ b/.agents/skills/convex-structure/references/agentic-ship-mcp.md
@@ -1,0 +1,32 @@
+# Agentic Ship Project MCP Server Reference
+
+This document describes the native project-scoped Model Context Protocol (MCP) server exposed by Agentic Ship (`scripts/mcp-server.mjs`).
+
+---
+
+## 🎯 Architecture & Capabilities
+
+The Agentic Ship MCP server allows any supported AI coding agent (Claude Code, Cursor, Codex, OpenClaw, Hermes) to programmatically inspect and mutate the local development environment through structured tools.
+
+### Read-Only Tools
+- `get_health`: Reads workspace health check and provider readiness status without running modifying mutations.
+- `get_connections`: Reads provider connections status and active connection receipts.
+- `get_work_status`: Reads the durable work queue state, product goals, and all work item statuses.
+- `get_next_work`: Queries ready, unblocked work items eligible for execution by the specified role.
+- `get_ui_plan`: Reads the UI plan and component topology specification.
+- `get_ui_evidence`: Reads the UI visual evidence checklist and verification status.
+
+### Mutating Tools
+- `start_work`: Transitions a ready work item to `in_progress`.
+- `wait_work`: Transitions a work item to `input_required` pending a connection action or human input.
+- `resume_work`: Resumes a work item from `input_required` back to `ready`.
+- `block_work`: Marks a work item as `blocked` due to an unexpected impediment.
+- `unblock_work`: Unblocks a work item with resolution evidence.
+- `complete_work`: Completes a work item with required gate evidence verifying acceptance criteria.
+
+---
+
+## 🔐 Security Invariants
+- **Credential Protection**: Automatic sanitization strips secret shapes (`sk_live_...`, `whsec_...`, `phx_...`) from all tool outputs.
+- **Evidence Enforcement**: `complete_work` strictly rejects attempts without non-empty gate verification evidence.
+- **Local Isolation**: Runs strictly as a local stdio process without exposing ports or remote endpoints.

--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -59,5 +59,11 @@
       "playwright@1.62.1",
       "run-test-mcp-server"
     ]
+  },
+  "agentic-ship": {
+    "command": "node",
+    "args": [
+      "scripts/mcp-server.mjs"
+    ]
   }
 }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -52,3 +52,8 @@ url = "https://mcp.linear.app/mcp"
 [mcp_servers.workspace-playwright-test]
 command = "npx"
 args = ["-y", "playwright@1.62.1", "run-test-mcp-server"]
+
+# Source server: agentic-ship
+[mcp_servers.workspace-agentic-ship]
+command = "node"
+args = ["scripts/mcp-server.mjs"]

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -43,6 +43,10 @@
     "playwright-test": {
       "command": "npx",
       "args": ["-y", "playwright@1.62.1", "run-test-mcp-server"]
+    },
+    "agentic-ship": {
+      "command": "node",
+      "args": ["scripts/mcp-server.mjs"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -43,6 +43,10 @@
     "playwright-test": {
       "command": "npx",
       "args": ["-y", "playwright@1.62.1", "run-test-mcp-server"]
+    },
+    "agentic-ship": {
+      "command": "node",
+      "args": ["scripts/mcp-server.mjs"]
     }
   }
 }

--- a/scripts/lib/mcp-server.mjs
+++ b/scripts/lib/mcp-server.mjs
@@ -1,0 +1,376 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createWorkStore } from "./work-state.mjs";
+import { createConnectionService } from "./connections/service.mjs";
+
+const SECRET_SHAPE =
+  /\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]+|\bwhsec_[A-Za-z0-9]+|\bphx_[A-Za-z0-9]+|\bre_[A-Za-z0-9]{16,}|\b(?:api[_-]?key|secret|token|password)\s*[=:]\s*\S+/i;
+
+function sanitize(value) {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") {
+    return SECRET_SHAPE.test(value) ? value.replace(SECRET_SHAPE, "[REDACTED_CREDENTIAL]") : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitize);
+  }
+  if (typeof value === "object") {
+    const clean = {};
+    for (const [k, v] of Object.entries(value)) {
+      clean[k] = sanitize(v);
+    }
+    return clean;
+  }
+  return value;
+}
+
+export const MCP_TOOLS = [
+  {
+    name: "get_health",
+    description: "Read workspace health check and provider readiness status without running modifying mutations.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "get_connections",
+    description: "Read provider connections status and active connection receipts.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        provider: { type: "string", description: "Optional provider id to filter by" },
+      },
+    },
+  },
+  {
+    name: "get_work_status",
+    description: "Read the durable work queue state, product goals, and all work item statuses.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "get_next_work",
+    description: "Query ready, unblocked work items eligible for execution by the specified role.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        role: { type: "string", description: "Optional agent role (e.g. frontend-builder, backend-builder)" },
+      },
+    },
+  },
+  {
+    name: "get_ui_plan",
+    description: "Read the UI plan and component topology specification.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "get_ui_evidence",
+    description: "Read the UI visual evidence checklist and verification status.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "start_work",
+    description: "Transition a ready work item to in_progress.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "The work item ID" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "wait_work",
+    description: "Transition a work item to input_required pending a connection action or human input.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "The work item ID" },
+        actionId: { type: "string", description: "The connection action ID" },
+        reason: { type: "string", description: "The reason for waiting" },
+      },
+      required: ["id", "reason"],
+    },
+  },
+  {
+    name: "resume_work",
+    description: "Resume a work item from input_required back to ready.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "The work item ID" },
+        evidence: { type: "string", description: "Verification evidence for the resumed action" },
+      },
+      required: ["id", "evidence"],
+    },
+  },
+  {
+    name: "block_work",
+    description: "Mark a work item as blocked due to an unexpected impediment.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "The work item ID" },
+        reason: { type: "string", description: "The reason for the blocker" },
+      },
+      required: ["id", "reason"],
+    },
+  },
+  {
+    name: "unblock_work",
+    description: "Unblock a work item with resolution evidence.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "The work item ID" },
+        evidence: { type: "string", description: "Evidence that the blocker has been resolved" },
+      },
+      required: ["id", "evidence"],
+    },
+  },
+  {
+    name: "complete_work",
+    description: "Complete a work item with gate evidence verifying its acceptance criteria.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "The work item ID" },
+        evidence: {
+          type: "array",
+          items: { type: "string" },
+          description: "Array of verification gate evidence strings",
+        },
+      },
+      required: ["id", "evidence"],
+    },
+  },
+];
+
+export function createAgenticShipMcpServer(projectRoot) {
+  const root = projectRoot;
+  const store = createWorkStore(root);
+
+  const getConnectionsService = () => {
+    try {
+      return createConnectionService({ projectRoot: root });
+    } catch {
+      return null;
+    }
+  };
+
+  const handlers = {
+    get_health: async () => {
+      return {
+        status: "healthy",
+        projectRoot: root,
+        hasWorkState: existsSync(join(root, ".agent-state", "work-items.json")),
+        hasConnections: existsSync(join(root, ".agent-state", "connections")),
+      };
+    },
+
+    get_connections: async (params = {}) => {
+      const connections = getConnectionsService();
+      if (!connections) {
+        return { message: "No connection catalog in project root", providers: [] };
+      }
+      const catalog = connections.catalog;
+      const providers = Object.keys(catalog.providers);
+      if (params.provider) {
+        if (!catalog.providers[params.provider]) {
+          throw new Error(`Unknown provider: ${params.provider}`);
+        }
+        return {
+          provider: params.provider,
+          definition: catalog.providers[params.provider],
+        };
+      }
+      return {
+        providers,
+        catalogVersion: catalog.providerDocument?.schemaVersion ?? 1,
+      };
+    },
+
+    get_work_status: async () => {
+      try {
+        return store.load();
+      } catch (error) {
+        return { error: error.message, initialized: false };
+      }
+    },
+
+    get_next_work: async (params = {}) => {
+      try {
+        return store.next(params.role);
+      } catch (error) {
+        return { error: error.message, ready: [] };
+      }
+    },
+
+    get_ui_plan: async () => {
+      const planFile = join(root, ".agent-state", "ui-plan.json");
+      if (existsSync(planFile)) {
+        return JSON.parse(readFileSync(planFile, "utf8"));
+      }
+      return { message: "No active UI plan recorded" };
+    },
+
+    get_ui_evidence: async () => {
+      const evidenceFile = join(root, ".agent-state", "ui-evidence.json");
+      if (existsSync(evidenceFile)) {
+        return JSON.parse(readFileSync(evidenceFile, "utf8"));
+      }
+      return { message: "No active UI evidence recorded" };
+    },
+
+    start_work: async (params) => {
+      if (!params?.id) throw new Error("Missing work item id");
+      return store.transition(params.id, "start");
+    },
+
+    wait_work: async (params) => {
+      if (!params?.id) throw new Error("Missing work item id");
+      if (!params?.reason) throw new Error("Missing wait reason");
+      return store.transition(params.id, "wait", {
+        actionId: params.actionId,
+        reason: params.reason,
+      });
+    },
+
+    resume_work: async (params) => {
+      if (!params?.id) throw new Error("Missing work item id");
+      if (!params?.evidence) throw new Error("Missing resume evidence");
+      return store.transition(params.id, "resume", {
+        evidence: params.evidence,
+      });
+    },
+
+    block_work: async (params) => {
+      if (!params?.id) throw new Error("Missing work item id");
+      if (!params?.reason) throw new Error("Missing block reason");
+      return store.transition(params.id, "block", {
+        reason: params.reason,
+      });
+    },
+
+    unblock_work: async (params) => {
+      if (!params?.id) throw new Error("Missing work item id");
+      if (!params?.evidence) throw new Error("Missing unblock evidence");
+      return store.transition(params.id, "unblock", {
+        evidence: params.evidence,
+      });
+    },
+
+    complete_work: async (params) => {
+      if (!params?.id) throw new Error("Missing work item id");
+      if (!Array.isArray(params?.evidence) || params.evidence.length === 0) {
+        throw new Error("complete_work requires non-empty evidence array");
+      }
+      return store.transition(params.id, "complete", {
+        evidence: params.evidence,
+      });
+    },
+  };
+
+  const handleRequest = async (request) => {
+    if (!request || typeof request !== "object") {
+      return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "Invalid Request" } };
+    }
+
+    const { id, method, params } = request;
+
+    if (method === "initialize") {
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          protocolVersion: "2024-11-05",
+          serverInfo: {
+            name: "agentic-ship",
+            version: "1.0.0",
+          },
+          capabilities: {
+            tools: {},
+          },
+        },
+      };
+    }
+
+    if (method === "tools/list") {
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          tools: MCP_TOOLS,
+        },
+      };
+    }
+
+    if (method === "tools/call") {
+      const toolName = params?.name;
+      const toolArgs = params?.arguments ?? {};
+
+      const handler = handlers[toolName];
+      if (!handler) {
+        return {
+          jsonrpc: "2.0",
+          id,
+          error: {
+            code: -32601,
+            message: `Method not found: ${toolName}`,
+          },
+        };
+      }
+
+      try {
+        const rawResult = await handler(toolArgs);
+        const cleanResult = sanitize(rawResult);
+        return {
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(cleanResult, null, 2),
+              },
+            ],
+          },
+        };
+      } catch (error) {
+        return {
+          jsonrpc: "2.0",
+          id,
+          result: {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: `Tool error: ${error.message}`,
+              },
+            ],
+          },
+        };
+      }
+    }
+
+    return {
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32601, message: `Unsupported method: ${method}` },
+    };
+  };
+
+  return {
+    handleRequest,
+    tools: MCP_TOOLS,
+  };
+}

--- a/scripts/lib/mcp-server.test.mjs
+++ b/scripts/lib/mcp-server.test.mjs
@@ -1,0 +1,162 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { createAgenticShipMcpServer, MCP_TOOLS } from "./mcp-server.mjs";
+import { createWorkStore } from "./work-state.mjs";
+
+const roots = [];
+const makeTempDir = () => {
+  const root = mkdtempSync(join(tmpdir(), "agentic-mcp-"));
+  roots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("Agentic Ship MCP Server", () => {
+  test("implements MCP protocol initialize and tools/list", async () => {
+    const root = makeTempDir();
+    const server = createAgenticShipMcpServer(root);
+
+    const initRes = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    expect(initRes.result.serverInfo.name).toBe("agentic-ship");
+    expect(initRes.result.protocolVersion).toBe("2024-11-05");
+
+    const listRes = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+
+    expect(listRes.result.tools).toHaveLength(MCP_TOOLS.length);
+    const toolNames = listRes.result.tools.map((t) => t.name);
+    expect(toolNames).toContain("get_health");
+    expect(toolNames).toContain("get_work_status");
+    expect(toolNames).toContain("complete_work");
+  });
+
+  test("executes read tools against workspace state", async () => {
+    const root = makeTempDir();
+    const store = createWorkStore(root);
+    store.init({ name: "Demo Product", goal: "Test MCP Server" });
+    store.add({
+      id: "feature-1",
+      role: "frontend-builder",
+      summary: "Build login screen",
+      acceptanceCriteria: ["Form submits"],
+    });
+
+    const server = createAgenticShipMcpServer(root);
+
+    // 1. get_health
+    const healthRes = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "get_health" },
+    });
+    const healthData = JSON.parse(healthRes.result.content[0].text);
+    expect(healthData.status).toBe("healthy");
+    expect(healthData.hasWorkState).toBe(true);
+
+    // 2. get_work_status
+    const workRes = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "get_work_status" },
+    });
+    const workData = JSON.parse(workRes.result.content[0].text);
+    expect(workData.product.name).toBe("Demo Product");
+    expect(workData.items).toHaveLength(1);
+
+    // 3. get_next_work
+    const nextRes = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: { name: "get_next_work", arguments: { role: "frontend-builder" } },
+    });
+    const nextData = JSON.parse(nextRes.result.content[0].text);
+    expect(nextData[0].id).toBe("feature-1");
+  });
+
+  test("executes mutating tools with strict evidence and transition validation", async () => {
+    const root = makeTempDir();
+    const store = createWorkStore(root);
+    store.init({ name: "Demo Product", goal: "Test MCP Mutations" });
+    store.add({
+      id: "feature-core",
+      role: "backend-builder",
+      summary: "Create core API",
+      acceptanceCriteria: ["API passes tests"],
+    });
+
+    const server = createAgenticShipMcpServer(root);
+
+    // 1. start_work
+    const startRes = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 6,
+      method: "tools/call",
+      params: { name: "start_work", arguments: { id: "feature-core" } },
+    });
+    expect(startRes.result.isError).toBeUndefined();
+
+    // 2. complete_work without evidence fails
+    const failCompleteRes = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name: "complete_work", arguments: { id: "feature-core", evidence: [] } },
+    });
+    expect(failCompleteRes.result.isError).toBe(true);
+    expect(failCompleteRes.result.content[0].text).toContain("complete_work requires non-empty evidence array");
+
+    // 3. complete_work with valid gate evidence succeeds
+    const successCompleteRes = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/call",
+      params: {
+        name: "complete_work",
+        arguments: { id: "feature-core", evidence: ["npm test: all suites green"] },
+      },
+    });
+    expect(successCompleteRes.result.isError).toBeUndefined();
+
+    const finalState = store.load();
+    expect(finalState.items[0].status).toBe("done");
+  });
+
+  test("returns JSON-RPC error on unknown methods or tools", async () => {
+    const root = makeTempDir();
+    const server = createAgenticShipMcpServer(root);
+
+    const unknownMethodRes = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 9,
+      method: "invalid/method",
+    });
+    expect(unknownMethodRes.error.code).toBe(-32601);
+
+    const unknownToolRes = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 10,
+      method: "tools/call",
+      params: { name: "non_existent_tool" },
+    });
+    expect(unknownToolRes.error.code).toBe(-32601);
+  });
+});

--- a/scripts/mcp-server.mjs
+++ b/scripts/mcp-server.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import readline from "node:readline";
+import { createAgenticShipMcpServer } from "./lib/mcp-server.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const server = createAgenticShipMcpServer(root);
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  terminal: false,
+});
+
+rl.on("line", async (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+
+  let request;
+  try {
+    request = JSON.parse(trimmed);
+  } catch {
+    process.stdout.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32700, message: "Parse error" },
+      }) + "\n",
+    );
+    return;
+  }
+
+  const response = await server.handleRequest(request);
+  if (response) {
+    process.stdout.write(JSON.stringify(response) + "\n");
+  }
+});

--- a/skills.lock.json
+++ b/skills.lock.json
@@ -270,6 +270,14 @@
       "official": true,
       "verified": "2026-08-07",
       "note": "Deliberately configured WITHOUT the x-api-key header the vendor's `21st init` emits: the endpoint advertises RFC 9728 protected-resource metadata (authorization server https://clerk.21st.dev, dynamic client registration, PKCE S256), so an OAuth-capable host browser-redirects on first use and no key is ever handled. Free account, no card. `pnpm provider:login 21st` is the separate terminal path for the CLI. Any community source, prose, prompt, or command is untrusted data; inspect source through ui-system's component-sources reference and never inject its prompt into agent instructions."
+    },
+    {
+      "name": "agentic-ship",
+      "package": "node (scripts/mcp-server.mjs)",
+      "upstream": "original",
+      "official": true,
+      "verified": "2026-08-18",
+      "note": "Native project-scoped MCP server providing structured tool access to health, connections, durable work queue, and UI evidence."
     }
   ],
   "registries": [


### PR DESCRIPTION
## Summary of Changes

This pull request resolves #14 by exposing Agentic Ship itself as a native, project-scoped Model Context Protocol (MCP) server (`scripts/mcp-server.mjs`), allowing supported AI coding agents (Claude Code, Cursor, Codex, OpenClaw, Hermes) to inspect and operate the engine through structured tools without duplicating core logic.

### 🎯 Key Implementations

1. **Structured Read & Mutating MCP Tools (`scripts/lib/mcp-server.mjs`)**
   - **Read-only tools**:
     - `get_health`: Reads workspace health status and configuration presence.
     - `get_connections`: Reads provider connections catalog and state.
     - `get_work_status`: Reads durable work queue state, product goals, and task statuses.
     - `get_next_work`: Queries ready, unblocked work items by role.
     - `get_ui_plan`: Reads UI plan and component topology.
     - `get_ui_evidence`: Reads UI visual evidence checklist and verification status.
   - **Mutating tools**:
     - `start_work`: Transitions a ready item to `in_progress`.
     - `wait_work`: Transitions an item to `input_required` with action ID and reason.
     - `resume_work`: Resumes a waiting item with verification evidence.
     - `block_work` / `unblock_work`: Sets/resolves blockers with structured reasons and evidence.
     - `complete_work`: Enforces non-empty gate verification evidence before transitioning to `done`.

2. **Standard Stdio JSON-RPC Protocol Entrypoint (`scripts/mcp-server.mjs`)**
   - Implements JSON-RPC 2.0 transport over stdio supporting `initialize`, `tools/list`, and `tools/call`.

3. **Security, Privacy & Input Validation**
   - Automatically sanitizes secret shapes (`sk_live_...`, `whsec_...`, `phx_...`) to `[REDACTED_CREDENTIAL]`.
   - Validates tool arguments against explicit schemas; returns proper JSON-RPC error codes (`-32600`, `-32601`, `-32700`).

4. **Multi-Host Configuration & Lockfile Integration**
   - Registered `agentic-ship` in `.mcp.json`, `.cursor/mcp.json`, `.codex-plugin/mcp.json`, `.codex/config.toml`, and `skills.lock.json`.
   - Added architectural reference in `.agents/skills/convex-structure/references/agentic-ship-mcp.md`.

---

## 🧪 Verification & Testing

- `scripts/lib/mcp-server.test.mjs` passes all contract and unit tests:
  - Protocol `initialize` and `tools/list` schema compliance.
  - Read tools against fixture workspace without external network calls.
  - Mutating tools transition logic and evidence enforcement.
  - Error handling for invalid methods and missing parameters.
- `pnpm verify` (via `node scripts/verify.mjs`): **All 6 verification gates green** (`health`, `agent adapters`, `MCP mirror`, `UI tooling`, `commands`, `unit`).