### PR TITLE
feat(ci): publish reusable Agentic Ship verification GitHub Action (#21)

### DIFF
--- a/.agents/skills/production-preflight/references/github-action-verify.md
+++ b/.agents/skills/production-preflight/references/github-action-verify.md
@@ -1,0 +1,49 @@
+# Reusable Agentic Ship Verification GitHub Action
+
+This document specifies the pinned, reusable GitHub Action and workflow for running Agentic Ship offline verification gates across downstream projects.
+
+---
+
+## 🎯 Usage in Downstream Projects
+
+Add `.github/workflows/verify.yml` to your downstream project:
+
+```yaml
+name: Verify
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    uses: moasq/agentic-ship/.github/workflows/verify-reusable.yml@main
+    with:
+      node-version: "22"
+      pnpm-version: "9"
+      audit: false
+```
+
+Or invoke the action directly via `uses: moasq/agentic-ship@main`:
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: moasq/agentic-ship@main
+    with:
+      audit: false
+```
+
+---
+
+## 🛡️ Security & Privacy Guarantees
+
+1. **Minimal Permissions**: The action and workflow operate under `permissions: { contents: read }`.
+2. **Immutable Action Pinning**: All third-party action dependencies (`setup-node`, `pnpm-setup`, `checkout`) are pinned to immutable commit SHAs.
+3. **Secret Redaction**: Error logs, annotations, and Step Summaries automatically redact sensitive tokens (`sk_live_`, `whsec_`, `phx_`, Bearer tokens).
+4. **Offline Isolation**: Does not upload `.agent-state/`, environment files, or unencrypted artifacts.

--- a/.github/workflows/verify-reusable.yml
+++ b/.github/workflows/verify-reusable.yml
@@ -1,0 +1,62 @@
+name: "Agentic Ship Verification (Reusable)"
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Node.js version to install"
+        required: false
+        type: string
+        default: "22"
+      pnpm-version:
+        description: "pnpm version to install"
+        required: false
+        type: string
+        default: "9"
+      audit:
+        description: "Whether to run an explicit opt-in dependency security audit"
+        required: false
+        type: boolean
+        default: false
+      fail-on-warnings:
+        description: "Whether warnings should fail the step"
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      passed:
+        description: "Whether all verification gates passed"
+        value: ${{ jobs.verify.outputs.passed }}
+      gates-passed:
+        description: "Count of passing gates"
+        value: ${{ jobs.verify.outputs.gates-passed }}
+      gates-total:
+        description: "Total count of evaluated gates"
+        value: ${{ jobs.verify.outputs.gates-total }}
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Offline Verification Gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      passed: ${{ steps.verify-action.outputs.passed }}
+      gates-passed: ${{ steps.verify-action.outputs.gates-passed }}
+      gates-total: ${{ steps.verify-action.outputs.gates-total }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Run Verification Action
+        id: verify-action
+        uses: ./
+        with:
+          node-version: ${{ inputs.node-version }}
+          pnpm-version: ${{ inputs.pnpm-version }}
+          audit: ${{ inputs.audit }}
+          fail-on-warnings: ${{ inputs.fail-on-warnings }}

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,68 @@
+name: "Agentic Ship Verification"
+description: "Runs deterministic offline verification gates, emits GitHub annotations, and generates job summaries."
+author: "moasq & contributors"
+
+inputs:
+  node-version:
+    description: "Node.js version to install"
+    required: false
+    default: "22"
+  pnpm-version:
+    description: "pnpm version to install"
+    required: false
+    default: "9"
+  working-directory:
+    description: "Working directory relative to repository root"
+    required: false
+    default: "."
+  audit:
+    description: "Whether to run an explicit opt-in dependency security audit"
+    required: false
+    default: "false"
+  fail-on-warnings:
+    description: "Whether warnings should fail the step"
+    required: false
+    default: "false"
+
+outputs:
+  passed:
+    description: "Whether all verification gates passed ('true' or 'false')"
+    value: ${{ steps.run-verify.outputs.passed }}
+  gates-passed:
+    description: "Count of passing gates"
+    value: ${{ steps.run-verify.outputs.gates-passed }}
+  gates-total:
+    description: "Total count of evaluated gates"
+    value: ${{ steps.run-verify.outputs.gates-total }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@a3252b78c470c02df07e9d792d4e7f4c51480f2d # v3.0.0
+      with:
+        version: ${{ inputs.pnpm-version }}
+        run_install: false
+
+    - name: Setup Node.js
+      uses: actions/setup-node@60edb5dd545a775178f525247059d61022244261 # v4.0.2
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: "pnpm"
+        cache-dependency-path: "${{ inputs.working-directory }}/pnpm-lock.yaml"
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        pnpm install --frozen-lockfile
+
+    - name: Run Agentic Ship Verification
+      id: run-verify
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        INPUT_AUDIT: ${{ inputs.audit }}
+        INPUT_FAIL_ON_WARNINGS: ${{ inputs.fail-on-warnings }}
+      run: |
+        node scripts/lib/action-verify-runner.mjs

--- a/scripts/lib/action-verify-runner.mjs
+++ b/scripts/lib/action-verify-runner.mjs
@@ -1,0 +1,146 @@
+import { execSync } from "node:child_process";
+import { appendFileSync, existsSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SECRET_PATTERNS = [
+  /sk_live_[0-9a-zA-Z]{24,}/g,
+  /whsec_[0-9a-zA-Z]{24,}/g,
+  /phx_[0-9a-zA-Z]{24,}/g,
+  /bearer\s+[a-zA-Z0-9_\-\.]{20,}/gi,
+];
+
+export function sanitizeText(text) {
+  if (typeof text !== "string") return "";
+  let out = text;
+  for (const pat of SECRET_PATTERNS) {
+    out = out.replace(pat, "[REDACTED_SECRET]");
+  }
+  return out;
+}
+
+export function formatStepSummary(gates, auditResult = null) {
+  const lines = [
+    "## 🚢 Agentic Ship Offline Verification Summary",
+    "",
+    "| Gate | Name | Status | Details |",
+    "| :--- | :--- | :---: | :--- |",
+  ];
+
+  for (const g of gates) {
+    const icon = g.passed ? "✅" : "❌";
+    const details = sanitizeText(g.details || (g.passed ? "Passed cleanly" : "Failed"));
+    lines.push(`| Gate ${g.id} | ${g.name} | ${icon} | ${details} |`);
+  }
+
+  if (auditResult) {
+    lines.push("");
+    lines.push("### 🛡️ Dependency Security Audit");
+    lines.push(
+      auditResult.passed
+        ? "✅ No high or critical vulnerabilities found."
+        : `⚠️ Audit reported vulnerabilities: ${sanitizeText(auditResult.summary)}`
+    );
+  }
+
+  lines.push("");
+  lines.push(`*Generated at ${new Date().toISOString()} by Agentic Ship Verification Action*`);
+  return lines.join("\n");
+}
+
+export function formatGitHubAnnotation(gate) {
+  if (gate.passed) return null;
+  const message = sanitizeText(gate.details || `Verification Gate ${gate.id} (${gate.name}) failed.`);
+  return `::error title=Gate ${gate.id} Failed (${gate.name})::${message}`;
+}
+
+export async function runVerificationGates(options = {}) {
+  const { audit = false, failOnWarnings = false } = options;
+  const gates = [
+    { id: 1, name: "Lint & Code Quality", command: "pnpm lint", passed: true, details: "" },
+    { id: 2, name: "Typecheck & Schema Validation", command: "pnpm typecheck", passed: true, details: "" },
+    { id: 3, name: "Unit & Integration Tests", command: "pnpm test", passed: true, details: "" },
+    { id: 4, name: "Agent Skills & Contracts", command: "node scripts/verify-skills.mjs", passed: true, details: "" },
+    { id: 5, name: "Connections & Providers", command: "node scripts/verify-connections.mjs", passed: true, details: "" },
+    { id: 6, name: "Work Queue & State Integrity", command: "node scripts/verify-work-queue.mjs", passed: true, details: "" },
+  ];
+
+  let allPassed = true;
+
+  for (const gate of gates) {
+    try {
+      execSync(gate.command, { stdio: "pipe", encoding: "utf8" });
+      gate.passed = true;
+      gate.details = "Gate passed cleanly";
+    } catch (err) {
+      gate.passed = false;
+      const stderr = err.stderr || err.stdout || err.message || "Execution error";
+      gate.details = stderr.trim().split("\n")[0] || "Command failed with non-zero exit code";
+      allPassed = false;
+    }
+  }
+
+  let auditResult = null;
+  if (audit) {
+    try {
+      execSync("pnpm audit --prod", { stdio: "pipe", encoding: "utf8" });
+      auditResult = { passed: true, summary: "No production vulnerabilities" };
+    } catch (err) {
+      const summary = err.stdout || err.stderr || "Vulnerabilities detected";
+      auditResult = { passed: false, summary: summary.trim().split("\n")[0] };
+      if (failOnWarnings) {
+        allPassed = false;
+      }
+    }
+  }
+
+  return { gates, allPassed, auditResult };
+}
+
+export async function main() {
+  const audit = process.env.INPUT_AUDIT === "true";
+  const failOnWarnings = process.env.INPUT_FAIL_ON_WARNINGS === "true";
+
+  console.log("🚢 Running Agentic Ship Verification Gates...");
+  const { gates, allPassed, auditResult } = await runVerificationGates({ audit, failOnWarnings });
+
+  for (const gate of gates) {
+    if (!gate.passed) {
+      const ann = formatGitHubAnnotation(gate);
+      if (ann) console.log(ann);
+    }
+  }
+
+  const summaryMarkdown = formatStepSummary(gates, auditResult);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryMarkdown + "\n", "utf8");
+  }
+
+  const passedCount = gates.filter((g) => g.passed).length;
+  const totalCount = gates.length;
+
+  if (process.env.GITHUB_OUTPUT) {
+    const outputLines = [
+      `passed=${allPassed ? "true" : "false"}`,
+      `gates-passed=${passedCount}`,
+      `gates-total=${totalCount}`,
+    ].join("\n");
+    appendFileSync(process.env.GITHUB_OUTPUT, outputLines + "\n", "utf8");
+  }
+
+  console.log(`\nVerification Result: ${passedCount}/${totalCount} gates passed.`);
+
+  if (!allPassed) {
+    console.error("❌ Agentic Ship Verification Failed.");
+    process.exit(1);
+  }
+
+  console.log("✅ All Agentic Ship Verification Gates Passed!");
+}
+
+if (process.argv[1] && process.argv[1].endsWith("action-verify-runner.mjs")) {
+  main().catch((err) => {
+    console.error("Fatal action error:", err);
+    process.exit(1);
+  });
+}

--- a/scripts/lib/action-verify-runner.test.mjs
+++ b/scripts/lib/action-verify-runner.test.mjs
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatGitHubAnnotation,
+  formatStepSummary,
+  sanitizeText,
+} from "./action-verify-runner.mjs";
+
+describe("action-verify-runner", () => {
+  it("sanitizeText redacts sensitive keys and secret tokens", () => {
+    const dummyKey1 = ["sk", "live", "testmock123456789012345678"].join("_");
+    const dummyKey2 = ["whsec", "testmock9876543210abcdef98765432"].join("_");
+    const secretString = `Failed at auth ${dummyKey1} and ${dummyKey2}`;
+    const sanitized = sanitizeText(secretString);
+    expect(sanitized).not.toContain(dummyKey1);
+    expect(sanitized).not.toContain(dummyKey2);
+    expect(sanitized).toContain("[REDACTED_SECRET]");
+  });
+
+  it("formatStepSummary generates well-formed markdown table", () => {
+    const mockGates = [
+      { id: 1, name: "Lint", passed: true, details: "Clean" },
+      { id: 2, name: "Typecheck", passed: false, details: "Type error on line 42" },
+      { id: 3, name: "Tests", passed: true, details: "All passed" },
+    ];
+
+    const summary = formatStepSummary(mockGates);
+    expect(summary).toContain("## 🚢 Agentic Ship Offline Verification Summary");
+    expect(summary).toContain("| Gate 1 | Lint | ✅ | Clean |");
+    expect(summary).toContain("| Gate 2 | Typecheck | ❌ | Type error on line 42 |");
+    expect(summary).toContain("| Gate 3 | Tests | ✅ | All passed |");
+  });
+
+  it("formatStepSummary includes audit results when provided", () => {
+    const mockGates = [{ id: 1, name: "Lint", passed: true, details: "Clean" }];
+    const audit = { passed: true, summary: "0 vulnerabilities" };
+
+    const summary = formatStepSummary(mockGates, audit);
+    expect(summary).toContain("### 🛡️ Dependency Security Audit");
+    expect(summary).toContain("No high or critical vulnerabilities found");
+  });
+
+  it("formatGitHubAnnotation emits error annotation for failing gates only", () => {
+    const passingGate = { id: 1, name: "Lint", passed: true, details: "Clean" };
+    const failingGate = { id: 2, name: "Typecheck", passed: false, details: "Type mismatch error" };
+
+    expect(formatGitHubAnnotation(passingGate)).toBeNull();
+    const ann = formatGitHubAnnotation(failingGate);
+    expect(ann).toContain("::error title=Gate 2 Failed (Typecheck)::Type mismatch error");
+  });
+});


### PR DESCRIPTION
## Summary of Changes

This pull request resolves #21 by publishing a versioned, pinned, reusable GitHub Action (`action.yml`) and workflow (`.github/workflows/verify-reusable.yml`) for downstream Agentic Ship repositories to execute offline verification gates with native GitHub annotations and step summaries.

### 🎯 Key Implementations

1. **Reusable Composite Action (`action.yml`)**
   - Configures deterministic Node.js (v22) and pnpm (v9) environments with pinned immutable action SHAs.
   - Operates with minimal permissions (`contents: read`).
   - Supports inputs: `node-version`, `pnpm-version`, `working-directory`, `audit` (opt-in dependency audit), `fail-on-warnings`.
   - Exposes outputs: `passed`, `gates-passed`, `gates-total`.

2. **Native GitHub Reporting & Secret Redaction (`scripts/lib/action-verify-runner.mjs`)**
   - Executes offline gates: Lint, Typecheck, Unit Tests, Agent Skills & Contracts, Connections & Providers, and Work Queue Integrity.
   - Writes rich markdown summary table to `$GITHUB_STEP_SUMMARY`.
   - Emits `::error::` workflow command annotations on failing gates with exact failure context.
   - Enforces automatic regex redaction of sensitive credentials and secret tokens (`sk_live_`, `whsec_`, `phx_`, Bearer tokens).

3. **Reusable Workflow (`.github/workflows/verify-reusable.yml`)**
   - Enables one-line `uses: moasq/agentic-ship/.github/workflows/verify-reusable.yml@main` integration in downstream products.

4. **Testing & Documentation**
   - Unit test suite in `scripts/lib/action-verify-runner.test.mjs` verifying summary formatting, annotations, and secret redaction.
   - Reference documentation in `.agents/skills/production-preflight/references/github-action-verify.md`.

---

## 🧪 Verification & Testing

- `pnpm verify` (all 6 gates green):