### PR TITLE
fix(providers): complete the Vercel deployment adapter

### DIFF
--- a/.agents/connections/providers.json
+++ b/.agents/connections/providers.json
@@ -645,15 +645,16 @@
         "mcpServer": "vercel",
         "setupUrl": "https://vercel.com/",
         "instructions": [
-          "Vercel's validated OAuth for tooling is the CLI: `vercel login` opens a browser authorization page.",
-          "The manual equivalent is running `npx vercel login` yourself.",
+          "Vercel's validated OAuth for tooling is the official CLI: `vercel login` uses browser device authorization.",
+          "The manual equivalent is installing the Vercel CLI and running `vercel login` yourself.",
           "The credential lands in Vercel's global config directory outside this repository."
         ],
         "configurationProbe": {
           "id": "vercel-cli-paired",
           "label": "Vercel CLI is authenticated",
-          "type": "home_file_exists",
-          "homePath": ".vercel/auth.json",
+          "type": "command_succeeds",
+          "command": "vercel",
+          "args": ["whoami"],
           "required": true
         },
         "automation": {
@@ -669,39 +670,82 @@
       "projectProvisioning": {
         "setupUrl": "https://vercel.com/dashboard",
         "instructions": [
-          "`vercel link` links this repository to a Vercel project.",
-          "`vercel.json` configures build commands and routes.",
-          "Set `CONVEX_DEPLOY_KEY` via `vercel env add CONVEX_DEPLOY_KEY production`."
+          "Choose an existing Vercel project or create a named project before linking this repository.",
+          "Commit `vercel.json` with `npx convex deploy --cmd 'pnpm build'` as its build command so Convex deploys before Next.js.",
+          "Vercel holds `CONVEX_DEPLOY_KEY` and required public browser variables only. Backend secrets remain in the production Convex environment."
         ],
         "verification": {
           "policy": "probe_and_attestation",
           "probes": [
             {
               "id": "vercel-config",
-              "label": "Vercel deployment config or project exists",
-              "type": "any_file_exists",
-              "paths": [
-                "vercel.json",
-                ".vercel/project.json"
-              ],
+              "label": "Vercel project is linked",
+              "type": "file_exists",
+              "path": ".vercel/project.json",
+              "required": true
+            },
+            {
+              "id": "vercel-config",
+              "label": "Vercel deployment config exists",
+              "type": "file_exists",
+              "path": "vercel.json",
+              "required": true
+            },
+            {
+              "id": "atomic-deploy",
+              "label": "Vercel deploys Convex and Next.js together",
+              "type": "file_contains",
+              "file": "vercel.json",
+              "text": "npx convex deploy --cmd 'pnpm build'",
               "required": true
             }
           ]
         },
         "automation": {
-          "run": [
-            {
-              "command": "vercel link",
-              "opensBrowser": true,
-              "why": "Link this directory to a Vercel project."
-            }
-          ]
+          "decision": {
+            "id": "vercel-project",
+            "question": "Should this workspace use an existing Vercel project or create a new one?",
+            "options": [
+              {
+                "value": "existing",
+                "label": "Link an existing project",
+                "placeholders": ["project-name"],
+                "run": [
+                  {
+                    "command": "vercel link --yes --project {project-name}",
+                    "opensBrowser": false,
+                    "why": "Link the workspace to the explicitly selected existing project."
+                  }
+                ]
+              },
+              {
+                "value": "new",
+                "label": "Create a new project",
+                "placeholders": ["project-name"],
+                "run": [
+                  {
+                    "command": "vercel project add {project-name}",
+                    "opensBrowser": false,
+                    "why": "Create the explicitly named Vercel project."
+                  },
+                  {
+                    "command": "vercel link --yes --project {project-name}",
+                    "opensBrowser": false,
+                    "why": "Link the workspace to the newly created project."
+                  }
+                ]
+              }
+            ]
+          }
         }
       },
       "revocation": [
         {
           "command": "vercel logout",
           "why": "Remove the Vercel CLI credential from this machine."
+        },
+        {
+          "text": "Unlink the local project by deleting `.vercel`, and remove the remote project or OAuth grant in Vercel if those resources should no longer exist."
         }
       ]
     },

--- a/.agents/connections/providers.json
+++ b/.agents/connections/providers.json
@@ -633,6 +633,78 @@
         }
       ]
     },
+    "vercel": {
+      "displayName": "Vercel",
+      "capability": "deployment",
+      "defaultForCapability": false,
+      "docsUrl": "https://vercel.com/docs/cli",
+      "actionTtlMinutes": 1440,
+      "maxVerificationAttempts": 5,
+      "agentTool": {
+        "authFlow": "cli_browser_login",
+        "mcpServer": "vercel",
+        "setupUrl": "https://vercel.com/",
+        "instructions": [
+          "Vercel's validated OAuth for tooling is the CLI: `vercel login` opens a browser authorization page.",
+          "The manual equivalent is running `npx vercel login` yourself.",
+          "The credential lands in Vercel's global config directory outside this repository."
+        ],
+        "configurationProbe": {
+          "id": "vercel-cli-paired",
+          "label": "Vercel CLI is authenticated",
+          "type": "home_file_exists",
+          "homePath": ".vercel/auth.json",
+          "required": true
+        },
+        "automation": {
+          "run": [
+            {
+              "command": "pnpm provider:login vercel",
+              "opensBrowser": true,
+              "why": "Install the official Vercel CLI if missing, then authenticate via browser."
+            }
+          ]
+        }
+      },
+      "projectProvisioning": {
+        "setupUrl": "https://vercel.com/dashboard",
+        "instructions": [
+          "`vercel link` links this repository to a Vercel project.",
+          "`vercel.json` configures build commands and routes.",
+          "Set `CONVEX_DEPLOY_KEY` via `vercel env add CONVEX_DEPLOY_KEY production`."
+        ],
+        "verification": {
+          "policy": "probe_and_attestation",
+          "probes": [
+            {
+              "id": "vercel-config",
+              "label": "Vercel deployment config or project exists",
+              "type": "any_file_exists",
+              "paths": [
+                "vercel.json",
+                ".vercel/project.json"
+              ],
+              "required": true
+            }
+          ]
+        },
+        "automation": {
+          "run": [
+            {
+              "command": "vercel link",
+              "opensBrowser": true,
+              "why": "Link this directory to a Vercel project."
+            }
+          ]
+        }
+      },
+      "revocation": [
+        {
+          "command": "vercel logout",
+          "why": "Remove the Vercel CLI credential from this machine."
+        }
+      ]
+    },
     "polar": {
       "displayName": "Polar",
       "capability": "billing",

--- a/.agents/heal-ledger.md
+++ b/.agents/heal-ledger.md
@@ -65,6 +65,21 @@ Format:
   and the absence of direct write permission and `pull_request_target`.
 - status: open
 
+## 2026-08-19 vercel-provider-trusted-a-guessed-token-path
+
+- cause: the first Vercel provider entry documented a login command the provider runner
+  did not support and treated a guessed home-directory file as proof of authentication.
+  It also accepted either an unlinked config file or a local link as complete project
+  provisioning, without checking the Convex-first build command.
+- fix: the official CLI is now installed and paired by `provider:login`; authentication
+  is verified with the read-only `vercel whoami` call. Provisioning requires an explicit
+  existing-or-new project decision, `.vercel/project.json`, and a committed
+  `vercel.json` whose build command deploys Convex before Next.js.
+- prevention: connection tests cover the exact read-only probe, project decision, link
+  receipt, and stale build config. A shared deployment-coherence gate rejects two active
+  adapters and validates both the Netlify default and Vercel alternative.
+- status: open
+
 ## 2026-08-11 visual-capture-hung-on-a-lazy-image
 - cause: `captureUiEvidence` awaited `image.decode()` on every image whose
   `complete` was false, with no bound. A below-the-fold `next/image` is lazy by

--- a/.agents/skills/convex-structure/references/deploy-vercel.md
+++ b/.agents/skills/convex-structure/references/deploy-vercel.md
@@ -1,0 +1,48 @@
+# Deploy — Vercel
+
+Reference for the service-connections, production-preflight, and convex-structure skills.
+
+---
+
+## 🚀 Overview
+
+Vercel provides native Next.js deployment with global Edge network routing and continuous integration from GitHub.
+
+---
+
+## 🛠️ Project Provisioning
+
+1. **Authentication**:
+   ```bash
+   pnpm provider:login vercel
+   # or
+   npx vercel login
+   ```
+
+2. **Link Project**:
+   ```bash
+   npx vercel link
+   ```
+
+3. **Deploy Key**:
+   Set `CONVEX_DEPLOY_KEY` in production environment:
+   ```bash
+   npx vercel env add CONVEX_DEPLOY_KEY production
+   ```
+
+4. **Ship**:
+   ```bash
+   npx vercel --prod
+   ```
+
+---
+
+## 🛡️ Secret Isolation
+
+| Variable | Location | Notes |
+| :--- | :--- | :--- |
+| `CONVEX_DEPLOY_KEY` | **Vercel** Project Env | Authorizes production builds |
+| `NEXT_PUBLIC_CONVEX_URL` | **Vercel** Project Env | Client connection pointer |
+| `BETTER_AUTH_SECRET`, `SITE_URL` | **prod Convex** deployment env | Backend only |
+| `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` | **prod Convex** deployment env | Backend only |
+| `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET` | **prod Convex** deployment env | Backend only |

--- a/.agents/skills/convex-structure/references/deploy-vercel.md
+++ b/.agents/skills/convex-structure/references/deploy-vercel.md
@@ -1,48 +1,64 @@
-# Deploy — Vercel
+# Deploy with Vercel
 
-Reference for the service-connections, production-preflight, and convex-structure skills.
+Use Vercel when the product brief selects `providerSelection.deployment: "vercel"`.
+Netlify remains the default. Keep one deployment adapter: a workspace with both
+`netlify.toml` and `vercel.json` fails preflight.
 
----
+## Connect and link
 
-## 🚀 Overview
+Run `pnpm onboard vercel --host <host>`. After consent, the agent installs the official
+CLI when needed, runs `vercel login`, and verifies the session with the read-only
+`vercel whoami` command. The credential remains in Vercel's machine-local store.
 
-Vercel provides native Next.js deployment with global Edge network routing and continuous integration from GitHub.
+Choose whether to link an existing project or create a named project. The connection
+receipt records that decision before it runs `vercel project add` or `vercel link`.
+Successful linking creates `.vercel/project.json`; that file is local provider state
+and must stay uncommitted.
 
----
+Commit this project configuration:
 
-## 🛠️ Project Provisioning
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npx convex deploy --cmd 'pnpm build'"
+}
+```
 
-1. **Authentication**:
-   ```bash
-   pnpm provider:login vercel
-   # or
-   npx vercel login
-   ```
+The build command deploys the production Convex functions before building Next.js.
+Running only `pnpm build` can ship a frontend against stale backend functions.
 
-2. **Link Project**:
-   ```bash
-   npx vercel link
-   ```
+## Environment ownership
 
-3. **Deploy Key**:
-   Set `CONVEX_DEPLOY_KEY` in production environment:
-   ```bash
-   npx vercel env add CONVEX_DEPLOY_KEY production
-   ```
+| Value | Location |
+| --- | --- |
+| `CONVEX_DEPLOY_KEY` | Vercel project environment; add for Preview and Production as appropriate |
+| `NEXT_PUBLIC_SITE_URL` | Vercel project environment for each public host |
+| `NEXT_PUBLIC_POSTHOG_KEY` | Vercel project environment when analytics is selected |
+| `BETTER_AUTH_SECRET`, `SITE_URL` | Production Convex environment |
+| Billing and email secrets | Production Convex environment |
 
-4. **Ship**:
-   ```bash
-   npx vercel --prod
-   ```
+Use `vercel env add <NAME> <environment>` so secret values are entered through the
+CLI prompt. Do not put values in `vercel.json`, chat, or connection receipts. Convex
+injects its public deployment URL while running the configured build command.
 
----
+## Deploy and verify
 
-## 🛡️ Secret Isolation
+Run a preview with `vercel deploy`, inspect it with `vercel inspect <preview-url>`, and
+check errors before promotion. Run production with `vercel deploy --prod`, then verify:
 
-| Variable | Location | Notes |
-| :--- | :--- | :--- |
-| `CONVEX_DEPLOY_KEY` | **Vercel** Project Env | Authorizes production builds |
-| `NEXT_PUBLIC_CONVEX_URL` | **Vercel** Project Env | Client connection pointer |
-| `BETTER_AUTH_SECRET`, `SITE_URL` | **prod Convex** deployment env | Backend only |
-| `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` | **prod Convex** deployment env | Backend only |
-| `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET` | **prod Convex** deployment env | Backend only |
+1. The production and preview URLs serve the expected commit over HTTPS.
+2. `SITE_URL` and `NEXT_PUBLIC_SITE_URL` match the production host, and the Better Auth
+   callback succeeds on that host.
+3. Billing and Resend webhooks still target the production Convex site URL; changing
+   the frontend host does not move those endpoints.
+4. A custom domain is attached to the intended Vercel project and has a valid
+   certificate before HSTS reaches users.
+5. `pnpm preflight --prod` passes, followed by the selected billing, email, and auth
+   production acceptance flows.
+
+## Revoke or replace
+
+`vercel logout` removes the local CLI session. Unlinking removes local `.vercel` state;
+deleting the remote project or OAuth grant is a separate Vercel action. To return to
+Netlify, remove `vercel.json`, restore the documented `netlify.toml`, update the product
+brief selection, and rerun connection verification and preflight.

--- a/.agents/skills/production-preflight/SKILL.md
+++ b/.agents/skills/production-preflight/SKILL.md
@@ -38,7 +38,7 @@ Exit 1 on any FAIL. Run `--prod` before every launch; the plain form on every de
 | prod `BETTER_AUTH_SECRET` set | sessions cannot be issued |
 | **`ALLOW_TEST_SEED` absent from prod** | anyone-callable seeding of production data |
 | no live key in `.env.local` | a live credential one `git add` from public |
-| `netlify.toml` still runs `npx convex deploy --cmd 'pnpm build'` | frontend ships against a stale backend |
+| the selected Netlify or Vercel adapter runs `npx convex deploy --cmd 'pnpm build'`, with no second adapter active | frontend ships against a stale backend or the wrong host |
 | `pnpm verify` + `pnpm test` green | launching a build that does not build |
 
 ## The judgment half (yours, or the agent's — not scriptable)
@@ -51,14 +51,14 @@ Exit 1 on any FAIL. Run `--prod` before every launch; the plain form on every de
    renewals, but only a live transaction proves the production pipeline.
 3. **Email round trip on prod:** sign up with a real address, receive the
    verification, complete it.
-4. **Rollback story:** know the last green deploy in Netlify before you need it.
+4. **Rollback story:** know the last green deploy in the selected host before you need it.
    Prod incidents get a rollback first, diagnosis second — never a patch loop on prod.
 5. **Convex prod is its own deployment** with its own env — confirm you set values with
    `--prod` and not into dev. `npx convex env list --prod` is the receipt.
 
 ## Order of flips (do not improvise)
 
-Same order as deploy-netlify's go-live checklist — the two documents deliberately agree:
+Same order as the selected deployment guide's go-live checklist:
 
 1. Verify the sending domain in Resend → set prod `EMAIL_FROM`. Preparation only —
    nothing sends yet while `testMode` holds.
@@ -69,6 +69,6 @@ Same order as deploy-netlify's go-live checklist — the two documents deliberat
 5. `pnpm preflight --prod` → all green
 6. Deploy, then the acceptance tests above
 
-Deep references, all under `convex-structure/references/`: `deploy-netlify.md` (env
-matrix, go-live checklist), `email-resend.md` (the 3-step email flip),
+Deep references, all under `convex-structure/references/`: `deploy-netlify.md` and
+`deploy-vercel.md` (env matrices and go-live checklists), `email-resend.md` (the 3-step email flip),
 `stripe-billing.md`, `polar-billing.md`, and `lemon-squeezy-billing.md`.

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -293,5 +293,4 @@ If no vulnerabilities found, state: "No high-confidence vulnerabilities identifi
 
 
 ### Infrastructure
-Not vendored — this stack deploys to managed hosting (Netlify + Convex). The upstream repository carries Docker, Kubernetes, Terraform, CI/CD, and cloud guides.
-
+Not vendored — this stack deploys to managed hosting (Netlify or Vercel with Convex). The upstream repository carries Docker, Kubernetes, Terraform, CI/CD, and cloud guides.

--- a/.agents/skills/service-connections/SKILL.md
+++ b/.agents/skills/service-connections/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: service-connections
-description: Use when connecting, authorizing, provisioning, resuming, verifying, canceling, or diagnosing an external service such as Convex, Stripe, GitHub, Resend, PostHog, or Netlify, especially when browser consent or another human-only step must pause an agent running in Claude Code, Codex, Cursor, Hermes, or OpenClaw.
+description: Use when connecting, authorizing, provisioning, resuming, verifying, canceling, or diagnosing an external service such as Convex, Stripe, GitHub, Resend, PostHog, Netlify, or Vercel, especially when browser consent or another human-only step must pause an agent running in Claude Code, Codex, Cursor, Hermes, or OpenClaw.
 ---
 
 # Service connections
@@ -65,7 +65,7 @@ When the result type is `input_required`, ask once, then act by runner:
    `opensBrowser` opens the provider's consent page and blocks until the user approves
    — run it, tell the user a browser is waiting for them, and let the command's own
    exit signal the consent. `pnpm provider:login <cli>` is that shape for providers
-   whose vendors ship CLI OAuth (Stripe pairing codes, Netlify browser login,
+   whose vendors ship CLI OAuth (Stripe pairing codes, Netlify or Vercel browser login,
    GitHub device flow): it installs the official CLI when missing and then waits on
    the browser approval. That blocking wait is the pause; do not poll around it,
    invent a callback, click the consent yourself, or edit global host configuration.

--- a/.agents/skills/service-connections/references/protocol.md
+++ b/.agents/skills/service-connections/references/protocol.md
@@ -53,7 +53,7 @@ collection. `input_required` additionally carries:
 - `agentRuns`: catalog `automation.run` steps the agent executes on the user's behalf —
   `command`, `why`, and `opensBrowser` when the command blocks on browser consent.
   `pnpm provider:login <cli>` steps install the vendor's official CLI when missing and
-  wait on its browser OAuth (Stripe pairing, Netlify login, GitHub device flow)
+  wait on its browser OAuth (Stripe pairing, Netlify or Vercel login, GitHub device flow)
 - `instructions`: the manual equivalent, safe actions with no credential values
 - `verification`: boolean probe results and safe summaries only
 - `sensitiveInputAllowed`: always `false`
@@ -90,6 +90,9 @@ types:
   this is how CLI OAuth pairing is detected (`.config/stripe/config.toml`,
   `.config/gh/hosts.yml`, `.config/netlify/config.json`) without reading the
   credential the pairing produced
+- `command_succeeds` — a fixed executable and literal arguments; use for a read-only
+  provider call when credential-file location is not a stable contract, and never
+  persist its output
 
 Choose `machine` only when local, non-secret signals prove readiness. Choose
 `probe_and_attestation` when provider dashboard state cannot be inspected safely. Add

--- a/.agents/skills/setup-health/references/connections.md
+++ b/.agents/skills/setup-health/references/connections.md
@@ -10,7 +10,7 @@ Load its protocol reference plus the selected records in:
 - `.agents/connections/hosts.json` for Claude Code, Codex, Cursor, Hermes, and OpenClaw consent
   instructions and read-only verification handoffs.
 
-Use the resumable connection workflow for Convex, Stripe, Resend, PostHog, and Netlify.
+Use the resumable connection workflow for Convex, Stripe, Resend, PostHog, Netlify, and Vercel.
 Keep these distinctions explicit:
 
 1. Host authorization grants the active AI tool access to a provider MCP or CLI.

--- a/.agents/skills/workspace-health/references/platform-notes.md
+++ b/.agents/skills/workspace-health/references/platform-notes.md
@@ -30,9 +30,9 @@ to write literally.
 accept it. `||`, `$(...)`, single quotes, and `2>/dev/null` are not — cmd.exe treats
 single quotes as literal characters. Scope of this rule: commands that must run on the
 **buyer's own shell** (package.json scripts and published commands).
-A command executed inside a known Linux container is exempt — `netlify.toml`'s
-`npx convex deploy --cmd 'pnpm build'` is the sanctioned example: Netlify builds run in
-bash, so the quotes are correct there and AGENTS.md mandates that exact line.
+A command executed inside a known Linux container is exempt. The committed Netlify and
+Vercel adapters use `npx convex deploy --cmd 'pnpm build'`: both providers run that
+build in Linux, so the quotes are correct there and AGENTS.md mandates the exact line.
 
 ## Why `.claude/skills` is generated, not just committed
 

--- a/.github/assets/stack/credits.md
+++ b/.github/assets/stack/credits.md
@@ -4,10 +4,10 @@ Brand marks used in `README.md` and `docs/stack.md` to identify the layers of th
 agentic development stack. Same rule as `.github/assets/hosts/credits.md`: one line per
 asset — file, source, licence — even where attribution is not required.
 
-Eighteen come from [Simple Icons](https://github.com/simple-icons/simple-icons)
+Nineteen come from [Simple Icons](https://github.com/simple-icons/simple-icons)
 (`simple-icons` on npm). Polar is sourced from its [official brand system](https://polar.sh/brand)
 because the similarly named Simple Icons mark belongs to the Polars dataframe library.
-All nineteen marks are vendored rather than hotlinked, so the pages render with no
+All twenty marks are vendored rather than hotlinked, so the pages render with no
 third-party request.
 
 | File | Mark | Slug | Licence |
@@ -28,6 +28,7 @@ third-party request.
 | `resend-{light,dark}.svg` | Resend | `resend` | CC0-1.0 |
 | `posthog-{light,dark}.svg` | PostHog | `posthog` | CC0-1.0 |
 | `netlify-{light,dark}.svg` | Netlify | `netlify` | CC0-1.0 |
+| `vercel-{light,dark}.svg` | Vercel | `vercel` | CC0-1.0 |
 | `github-{light,dark}.svg` | GitHub | `github` | CC0-1.0 |
 | `linear-{light,dark}.svg` | Linear | `linear` | CC0-1.0 |
 | `vitest-{light,dark}.svg` | Vitest | `vitest` | CC0-1.0 |

--- a/.github/assets/stack/vercel-dark.svg
+++ b/.github/assets/stack/vercel-dark.svg
@@ -1,0 +1,1 @@
+<svg fill="#e6edf3" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Vercel</title><path d="m12 1.608 12 20.784H0Z"/></svg>

--- a/.github/assets/stack/vercel-light.svg
+++ b/.github/assets/stack/vercel-light.svg
@@ -1,0 +1,1 @@
+<svg fill="#1f2328" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Vercel</title><path d="m12 1.608 12 20.784H0Z"/></svg>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ vercel/next.js repo is declared there). Provenance for all of it lives in
 Node 20+ · pnpm · TypeScript parser · Playwright capture runtime. Downstream product
 stacks are selected by their own product contract.
 
+Deployment selects **Netlify** by default or **Vercel** as an alternative; both use an
+official CLI browser login and a committed adapter that deploys Convex before Next.js.
 Delivery and tracking ride on two services: **GitHub** carries the repository, pull
 requests, and CI through the authenticated `gh` CLI (`pnpm provider:login github`), and
 **Linear** is the optional development-tracking mirror through its hosted MCP — both
@@ -67,7 +69,7 @@ Windows. The buyer may be on any of the three.
 | `pnpm health` | offline tool-repo health — required skill/contract/adapter/MCP assets present, no bundled application residue, Node 20+ runtime. (Product-workspace checks — pins, SSOT, tokens, env leaks, backend status — run downstream where `src/`/`convex/` exist) |
 | `pnpm onboard [provider] --host <host>` | provider-selective status or the next resumable human step |
 | `pnpm connect` | begin, inspect, resume, or cancel safe service-connection receipts |
-| `pnpm provider:login <cli>` | install + browser-OAuth pair a vendor's official CLI (stripe, netlify, github, 21st) |
+| `pnpm provider:login <cli>` | install + browser-OAuth pair a vendor's official CLI (stripe, netlify, vercel, github, 21st) |
 | `pnpm stripe:provision` | webhook endpoint and plan prices through the paired CLI; secrets flow straight into Convex env, never printed. `--test-key` copies the CLI's TEST key so a sandbox can take a 4242 payment; it refuses anything that is not `sk_test`/`rk_test`, and refuses `--prod` |
 | `pnpm secret:set NAME` | hidden-input prompt in the user's terminal, piped into Convex env — no chat, no history, no files |
 | `pnpm setup:auth [site-url]` | generate `BETTER_AUTH_SECRET` and set it plus `SITE_URL` straight into a downstream Convex env; the secret is never printed |
@@ -214,7 +216,7 @@ matrix through `visual-qa` before completion.
   provider page itself (`pnpm open:url`, restricted to catalog origins). On no, it
   cancels the receipt and runs nothing.
 - **Authorization is the vendor's own OAuth wherever one exists.** Convex, Stripe,
-  Netlify, and GitHub authorize through their official CLI browser flows
+  Netlify, Vercel, and GitHub authorize through their official CLI browser flows
   (`pnpm provider:login`), where approving in the browser is the entire consent and
   the credential lands only in the CLI's machine-local store. Choices the catalog
   cannot make — such as Convex's new-vs-existing project — are payload `decision`s
@@ -585,33 +587,38 @@ Detail: `.agents/skills/frontend-security/references/analytics-posthog.md`.
 - `autocapture` is off and inputs are masked in replay. Turning either on is a
   `frontend-security` decision, not a convenience.
 
-## Deploy rules (Netlify)
+## Deploy rules (Netlify or Vercel)
 
-Detail: `.agents/skills/convex-structure/references/deploy-netlify.md`.
+Details: `.agents/skills/convex-structure/references/deploy-netlify.md` and
+`.agents/skills/convex-structure/references/deploy-vercel.md`.
 
-- `netlify.toml` is the deployment. Change the topology there, in a reviewable diff —
-  never by clicking in a dashboard. Netlify treats the file as authoritative and it
-  **overrides** the UI, so a dashboard edit cannot silently win.
+- The product brief selects one deployment provider. Netlify remains the default;
+  Vercel is the supported alternative. Commit exactly one adapter: `netlify.toml` or
+  `vercel.json`. Preflight fails when both exist.
+- Change deployment topology in that adapter, in a reviewable diff. Dashboard settings
+  must not silently replace the committed build contract.
 - The build command must run `npx convex deploy --cmd 'pnpm build'`, so backend and
   frontend ship together. `pnpm build` alone ships a frontend against a stale backend.
-- Netlify holds `CONVEX_DEPLOY_KEY` and public keys only. Every backend secret lives in
+- The web host holds `CONVEX_DEPLOY_KEY` and public keys only. Every backend secret lives in
   the **prod Convex deployment's** env, which is what keeps live Stripe keys off dev
   machines.
-- Secret **values** never appear in `netlify.toml` — it is committed, and a value
-  written into it is published. Set them with `netlify env:set <NAME> --secret`.
-- **The whole path is the terminal**, which is why this host and not another:
-  `netlify init` creates the site and links the repo, `netlify env:set` configures it,
+- Secret **values** never appear in the committed deployment adapter. Set them through
+  the selected provider's hidden-input environment command.
+- **The whole path is the terminal**, which is why these hosts and not another.
+  Vercel uses `vercel project add`, `vercel link`, `vercel env add`, and
+  `vercel deploy --prod`. Netlify uses `netlify init` to create and link the site,
+  `netlify env:set` to configure it, and
   `netlify deploy --prod` ships. Nothing here needs a dashboard. Render was replaced for
   exactly this reason — `render deploys create` requires a `serviceID` that only the
   dashboard can mint, and `render blueprints` can validate a blueprint but never apply
   one, so the first deploy could not be reached from a terminal at all.
 - **The custom domain is the one human-owned deploy step.** It costs money and no
   registrar lets a machine buy or point one safely: the person buys it (Hostinger is
-  the documented registrar), points DNS at Netlify by hand, and the agent re-points
-  the app afterwards. Never announce the domain before Netlify shows the certificate
+  the documented registrar), points DNS at the selected host by hand, and the agent
+  re-points the app afterwards. Never announce the domain before the host shows the certificate
   issued — HSTS ships with a two-year `max-age`, so the first response a browser sees
   there must already be valid HTTPS. Procedure and records:
-  `.agents/skills/convex-structure/references/deploy-netlify.md`.
+  the selected deployment reference.
 
 ## Security rules
 
@@ -636,14 +643,14 @@ The kit's defaults are deliberately test-safe; going live is a set of **delibera
 flips**, gated by `pnpm preflight` and the `production-preflight` skill:
 
 - Live Stripe keys exist **only** in the prod Convex deployment's env. A live key on a
-  dev machine or in Netlify is a CRITICAL, and preflight `--prod` fails if prod still
+  dev machine or in the web host is a CRITICAL, and preflight `--prod` fails if prod still
   holds a test key — that is production taking test payments.
 - Email leaves `testMode` **together with** `requireEmailVerification: true`, after a
   sending domain is verified. Never one without the other.
 - `ALLOW_TEST_SEED` must not exist on prod. Preflight fails if it does.
 - `src/lib/site.ts` placeholders must be replaced before launch — they are the
   `<title>`, the OG card and llms.txt.
-- Prod incidents: rollback first (last green deploy in Netlify), diagnose locally
+- Prod incidents: rollback first (last green deploy in the selected host), diagnose locally
   through the gates second. Never a patch loop against production.
 
 ## SEO / AEO rules

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ reasoning behind each pick lives in [docs/stack.md](docs/stack.md).
 | Fonts | Self-hosted OFL faces, fetched by `pnpm font`, committed |
 | Gates | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/vitest-dark.svg"><img alt="" src=".github/assets/stack/vitest-light.svg" height="14"></picture> Vitest contracts · Playwright capture · deterministic Node checks — `pnpm verify` on every completion, `pnpm verify:full` before a release |
 | UI gates | `pnpm ui:plan` direction contract · `pnpm ui:review` visual evidence · `pnpm check:ui` component boundaries |
-| Deploy | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/netlify-dark.svg"><img alt="" src=".github/assets/stack/netlify-light.svg" height="14"></picture> Netlify — the whole path is the terminal, `netlify.toml` is authoritative |
+| Deploy | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/netlify-dark.svg"><img alt="" src=".github/assets/stack/netlify-light.svg" height="14"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/vercel-dark.svg"><img alt="" src=".github/assets/stack/vercel-light.svg" height="14"></picture> Netlify by default, or Vercel; each uses one committed adapter and deploys Convex before Next.js |
 | Delivery | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/github-dark.svg"><img alt="" src=".github/assets/stack/github-light.svg" height="14"></picture> GitHub — `gh` CLI device-flow OAuth for repo, PRs, and CI |
 | Tracking | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/github-dark.svg"><img alt="" src=".github/assets/stack/github-light.svg" height="14"></picture> GitHub Issues and Projects through `gh`, or <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/linear-dark.svg"><img alt="" src=".github/assets/stack/linear-light.svg" height="14"></picture> Linear through its hosted MCP; both mirror the local queue |
 | AI hosts | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/hosts/claude-code-dark.svg"><img alt="" src=".github/assets/hosts/claude-code-light.svg" height="14"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/hosts/codex-dark.svg"><img alt="" src=".github/assets/hosts/codex-light.svg" height="14"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/hosts/cursor-dark.svg"><img alt="" src=".github/assets/hosts/cursor-light.svg" height="14"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/hosts/hermes-dark.svg"><img alt="" src=".github/assets/hosts/hermes-light.svg" height="14"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/hosts/openclaw-dark.svg"><img alt="" src=".github/assets/hosts/openclaw-light.svg" height="14"></picture> Claude Code · Codex · Cursor · Windsurf · Cline · Copilot · Gemini CLI · Hermes · OpenClaw |
@@ -135,6 +135,23 @@ pnpm onboard polar --host codex
 pnpm onboard lemonsqueezy --host codex
 ```
 
+### Choose a deployment provider
+
+Product briefs select one deployment provider through `providerSelection.deployment`.
+Netlify is the default; Vercel is the supported alternative. Both use the provider's
+official browser login, keep backend secrets in Convex, and require an atomic
+`npx convex deploy --cmd 'pnpm build'` build.
+
+```bash
+pnpm onboard netlify --host codex
+pnpm onboard vercel --host codex
+```
+
+Read the [Netlify guide](.agents/skills/convex-structure/references/deploy-netlify.md)
+or [Vercel guide](.agents/skills/convex-structure/references/deploy-vercel.md) before
+production. `pnpm preflight` rejects a stale build command or two active deployment
+adapters.
+
 ### Not wired yet, and what a swap costs
 
 Opinionated does not mean stuck. Every provider sits behind a seam you own, so the
@@ -142,7 +159,7 @@ honest question is not "is it supported" but how much code a swap touches:
 
 | Want instead | Wired today | Swap cost |
 | --- | --- | --- |
-| Vercel, Cloudflare | Netlify | small — the deploy seam is `netlify.toml`, one build command, one doc; product code never names the host |
+| Cloudflare | Netlify, Vercel | small — add one committed deployment adapter and its connection and preflight contracts; product code never names the host |
 | Plausible, Umami | PostHog | small — `src/lib/analytics.ts` is the only file that imports the SDK |
 | Postmark, SendGrid | Resend | medium — `convex/email.ts` is the only sender, but the Convex component and its webhook go with it |
 | Paddle | Stripe, Polar, Lemon Squeezy | medium: add one provider-owned adapter, connection entry, lifecycle fixture, and production check |

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ move.
   the generated adapters, and the provenance lockfile.
 - [How do service connections work?](connections.md): consent-gated, receipt-backed,
   revocable connections to Convex, Stripe, GitHub, Linear, Resend, PostHog, and
-  Netlify.
+  Netlify, and Vercel.
 - [How do I see what the agents are doing?](tracking.md): the durable work queue, the
   Linear mirror, and the GitHub delivery seam.
 - [How are these docs written?](writing.md): the vendored writing skills and the gate

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -20,6 +20,7 @@ way to revoke it.
 | Resend | Email | Hosted MCP OAuth, keys via hidden input |
 | PostHog | Analytics | Hosted MCP OAuth, public `phc_` key only |
 | Netlify | Deploy | `netlify login` browser flow |
+| Vercel | Deploy (alternative) | `vercel login` device flow via `pnpm provider:login vercel` |
 
 The catalog behind this table is
 [.agents/connections/providers.json](../.agents/connections/providers.json): probes,
@@ -81,7 +82,7 @@ by ID and nothing more.
 
 `pnpm connect cancel <action-id>` retires the local receipt. Every catalog entry also
 names how access itself is withdrawn: `npx convex logout`, `stripe logout`,
-`gh auth logout`, `netlify logout`, or disconnecting the MCP server in the host and
+`gh auth logout`, `netlify logout`, `vercel logout`, or disconnecting the MCP server in the host and
 revoking the grant in the provider's security settings. Canceling tracking, for
 example, stops the Linear mirror immediately and leaves already-created issues to be
 archived in Linear itself.
@@ -93,7 +94,7 @@ The model deliberately separates concerns that look similar:
 - **AI-host MCP authorization**: the host's own OAuth to a hosted tool server (Stripe,
   Resend, PostHog, Linear, 21st). Approving in the browser is the entire consent.
 - **Project provisioning**: creating or linking the actual resources: a Convex project,
-  a Stripe webhook endpoint, a Netlify site, a Linear project.
+  a Stripe webhook endpoint, a Netlify or Vercel project, a Linear project.
 - **Customer runtime**: your product's users returning from Stripe Checkout. That flow
   belongs to the product, and entitlement comes only from the webhook-backed query,
   never from a redirect.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,9 +110,9 @@ pnpm preflight --prod
 
 It fails when the selected billing provider uses its test environment. It also fails
 when email remains in test mode without verification, when the seed backdoor flag
-exists, or when `src/lib/site.ts` still carries placeholders. Deploy through Netlify
-with `netlify init`, `netlify env:set` for the deploy key, then `netlify deploy --prod`.
-The committed `netlify.toml` is the authoritative deployment description. If
+exists, or when `src/lib/site.ts` still carries placeholders. Deploy through the
+provider selected in the product brief: Netlify by default, or Vercel. Its committed
+`netlify.toml` or `vercel.json` is the authoritative deployment description. If
 production misbehaves, roll back to the last green deploy first and diagnose locally
 second.
 

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -38,7 +38,7 @@ fail-closed dependency audit before anything ships.
 | Email | <picture><source media="(prefers-color-scheme: dark)" srcset="../.github/assets/stack/resend-dark.svg"><img alt="" src="../.github/assets/stack/resend-light.svg" height="14"></picture> Resend via `@convex-dev/resend` | Ships in test mode so a wrong address in development cannot reach a real person; leaving test mode is a paired, gated flip |
 | Analytics | <picture><source media="(prefers-color-scheme: dark)" srcset="../.github/assets/stack/posthog-dark.svg"><img alt="" src="../.github/assets/stack/posthog-light.svg" height="14"></picture> PostHog | The one analytics vendor with an official plugin that reads product data back; traffic proxies through `/ingest` on your own origin so the CSP stays closed |
 | Fonts | Self-hosted OFL faces | `next/font/google` downloads at build time, which once broke CI on a host with no egress; committed OFL files cannot |
-| Deploy | <picture><source media="(prefers-color-scheme: dark)" srcset="../.github/assets/stack/netlify-dark.svg"><img alt="" src="../.github/assets/stack/netlify-light.svg" height="14"></picture> Netlify | The whole path is the terminal: `netlify init`, `netlify env:set`, `netlify deploy --prod`; Render was dropped because its first deploy cannot be reached from a terminal at all |
+| Deploy | <picture><source media="(prefers-color-scheme: dark)" srcset="../.github/assets/stack/netlify-dark.svg"><img alt="" src="../.github/assets/stack/netlify-light.svg" height="14"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="../.github/assets/stack/vercel-dark.svg"><img alt="" src="../.github/assets/stack/vercel-light.svg" height="14"></picture> Netlify or Vercel | Netlify remains the default; Vercel is an explicit alternative. Both pair through an official CLI, keep one committed adapter, and deploy Convex before Next.js |
 | Delivery | <picture><source media="(prefers-color-scheme: dark)" srcset="../.github/assets/stack/github-dark.svg"><img alt="" src="../.github/assets/stack/github-light.svg" height="14"></picture> GitHub | Repository, pull requests, and CI through the `gh` CLI's device-flow OAuth; the token lands in the system keyring and is never typed |
 | Tracking | <picture><source media="(prefers-color-scheme: dark)" srcset="../.github/assets/stack/linear-dark.svg"><img alt="" src="../.github/assets/stack/linear-light.svg" height="14"></picture> Linear | The hosted Linear MCP mirrors the work queue into a project a person can watch; the queue stays the source of truth |
 
@@ -46,7 +46,7 @@ The brand marks in these tables are vendored, never hotlinked; provenance and th
 edit made to each file are recorded in
 [.github/assets/stack/credits.md](../.github/assets/stack/credits.md).
 
-Two rejected alternatives explain the flavor of these picks. Render lost to Netlify
+Two rejected alternatives explain the flavor of these picks. Render lost to the supported deployment adapters
 because a deploy that needs a dashboard-minted ID breaks the terminal-only rule.
 Amplitude lost to PostHog because its integration is events-first: it can receive data
 but gives an agent little to read back.

--- a/scripts/connect.mjs
+++ b/scripts/connect.mjs
@@ -14,7 +14,7 @@ function usage() {
     "  pnpm --silent connect resume <actionId> [--json]",
     "  pnpm --silent connect cancel <actionId> [--json]",
     "",
-    "Providers: convex, stripe, github, resend, posthog, netlify",
+    "Providers: convex, stripe, github, resend, posthog, netlify, vercel, polar, lemonsqueezy",
     "Hosts: claude, codex, cursor, hermes, openclaw",
   ].join("\n");
 }

--- a/scripts/health.mjs
+++ b/scripts/health.mjs
@@ -21,7 +21,7 @@ const required = [
 ];
 const missing = required.filter((path) => !existsSync(resolve(root, path)));
 const agents = existsSync(resolve(root, "AGENTS.md")) ? readFileSync(resolve(root, "AGENTS.md"), "utf8") : "";
-const appPaths = ["src", "convex", "public", "e2e", "next.config.ts", "netlify.toml"];
+const appPaths = ["src", "convex", "public", "e2e", "next.config.ts", "netlify.toml", "vercel.json"];
 const remainingApp = appPaths.filter((path) => existsSync(resolve(root, path)));
 const nodeMajor = Number(process.versions.node.split(".")[0]);
 const failures = [

--- a/scripts/lib/connections/catalog.mjs
+++ b/scripts/lib/connections/catalog.mjs
@@ -3,7 +3,7 @@ import { join, resolve } from "node:path";
 
 const IDENTIFIER = /^[a-z][a-z0-9-]*$/;
 const PLACEHOLDER = /\{([a-z][a-z0-9-]*)\}/g;
-const PROBE_TYPES = new Set(["any_file_exists", "env_file_key", "file_contains", "file_exists", "home_file_exists", "mcp_server"]);
+const PROBE_TYPES = new Set(["any_file_exists", "command_succeeds", "env_file_key", "file_contains", "file_exists", "home_file_exists", "mcp_server"]);
 const AUTH_FLOWS = new Set(["cli_browser_login", "remote_oauth"]);
 const VERIFICATION_POLICIES = new Set(["machine", "probe_and_attestation"]);
 const CAPABILITIES = new Set(["analytics", "backend", "billing", "deployment", "email", "repository", "tracking"]);
@@ -28,6 +28,13 @@ function validateProbe(probe, owner) {
   assert(PROBE_TYPES.has(probe.type), `${owner}.${probe.id} uses unsupported probe type ${probe.type}`);
   assert(typeof probe.required === "boolean", `${owner}.${probe.id} must declare required`);
   if (probe.type === "file_exists") assert(typeof probe.path === "string", `${owner}.${probe.id} needs a path`);
+  if (probe.type === "command_succeeds") {
+    assert(IDENTIFIER.test(probe.command ?? ""), `${owner}.${probe.id} needs a safe command name`);
+    assert(
+      Array.isArray(probe.args) && probe.args.every((arg) => typeof arg === "string" && !/[\r\n]/.test(arg)),
+      `${owner}.${probe.id} needs literal command arguments`,
+    );
+  }
   if (probe.type === "any_file_exists") {
     assert(Array.isArray(probe.paths) && probe.paths.length > 0 && probe.paths.every((path) => typeof path === "string"), `${owner}.${probe.id} needs paths`);
   }

--- a/scripts/lib/connections/probes.mjs
+++ b/scripts/lib/connections/probes.mjs
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 import { isAbsolute, relative, resolve } from "node:path";
 
@@ -56,7 +57,12 @@ function homePath(homeDirectory, candidate) {
   return path;
 }
 
-export function runConnectionProbe(probe, { projectRoot, homeDirectory }) {
+function runReadOnlyCommand(command, args) {
+  const executable = process.platform === "win32" ? `${command}.cmd` : command;
+  return spawnSync(executable, args, { stdio: "ignore" });
+}
+
+export function runConnectionProbe(probe, { projectRoot, homeDirectory, commandRunner = runReadOnlyCommand }) {
   if (probe.type === "file_exists") {
     const passed = existsSync(projectPath(projectRoot, probe.path));
     return probeResult(probe, passed, passed ? "detected" : "not detected");
@@ -67,6 +73,12 @@ export function runConnectionProbe(probe, { projectRoot, homeDirectory }) {
   if (probe.type === "home_file_exists") {
     const passed = existsSync(homePath(homeDirectory, probe.homePath));
     return probeResult(probe, passed, passed ? "detected" : "not detected");
+  }
+
+  if (probe.type === "command_succeeds") {
+    const result = commandRunner(probe.command, probe.args);
+    const passed = result.status === 0 && !result.error;
+    return probeResult(probe, passed, passed ? "authenticated read-only call passed" : "authenticated read-only call failed");
   }
 
   if (probe.type === "any_file_exists") {

--- a/scripts/lib/connections/service.test.mjs
+++ b/scripts/lib/connections/service.test.mjs
@@ -76,7 +76,7 @@ test("catalog exposes every supported provider and host", (t) => {
   assert.equal(result.type, "connection_status");
   assert.deepEqual(
     result.providers.map((provider) => provider.id),
-    ["convex", "stripe", "github", "linear", "resend", "posthog", "netlify", "polar", "lemonsqueezy"],
+    ["convex", "stripe", "github", "linear", "resend", "posthog", "netlify", "vercel", "polar", "lemonsqueezy"],
   );
   assert.deepEqual(result.supportedHosts, ["claude", "codex", "cursor", "hermes", "openclaw"]);
   assert.equal(result.providers.find((provider) => provider.id === "polar").agentToolConfiguration, null);
@@ -512,6 +512,6 @@ test("CLI status emits machine-readable JSON in an isolated state directory", (t
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
   assert.equal(output.type, "connection_status");
-  assert.equal(output.providers.length, 9);
+  assert.equal(output.providers.length, 10);
   assert.deepEqual(readdirSync(temporaryRoot), []);
 });

--- a/scripts/lib/connections/service.test.mjs
+++ b/scripts/lib/connections/service.test.mjs
@@ -8,6 +8,8 @@ import { fileURLToPath } from "node:url";
 import { pathToFileURL } from "node:url";
 import { test } from "vitest";
 import { ConnectionCommandError, createConnectionService } from "./service.mjs";
+import { loadConnectionCatalog } from "./catalog.mjs";
+import { runConnectionProbe } from "./probes.mjs";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const catalogDirectory = join(repositoryRoot, ".agents", "connections");
@@ -81,6 +83,51 @@ test("catalog exposes every supported provider and host", (t) => {
   assert.deepEqual(result.supportedHosts, ["claude", "codex", "cursor", "hermes", "openclaw"]);
   assert.equal(result.providers.find((provider) => provider.id === "polar").agentToolConfiguration, null);
   assert.equal(result.providers.find((provider) => provider.id === "lemonsqueezy").agentToolConfiguration, null);
+});
+
+test("Vercel uses a read-only CLI auth probe and explicit project choice", (t) => {
+  const { projectRoot, homeDirectory } = fixture(t);
+  const catalog = loadConnectionCatalog({ projectRoot, catalogDirectory });
+  const vercel = catalog.providers.vercel;
+  const calls = [];
+  const result = runConnectionProbe(vercel.agentTool.configurationProbe, {
+    projectRoot,
+    homeDirectory,
+    commandRunner(command, args) {
+      calls.push([command, args]);
+      return { status: 0 };
+    },
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(calls, [["vercel", ["whoami"]]]);
+  assert.deepEqual(
+    vercel.projectProvisioning.automation.decision.options.map((option) => option.value),
+    ["existing", "new"],
+  );
+});
+
+test("Vercel project verification requires the link and atomic build config", (t) => {
+  const { projectRoot, homeDirectory } = fixture(t);
+  const vercel = loadConnectionCatalog({ projectRoot, catalogDirectory }).providers.vercel;
+
+  const missing = vercel.projectProvisioning.verification.probes.map((probe) =>
+    runConnectionProbe(probe, { projectRoot, homeDirectory }),
+  );
+  assert.equal(missing.every((probe) => !probe.passed), true);
+
+  write(projectRoot, ".vercel/project.json", '{"projectId":"prj_test","orgId":"team_test"}');
+  write(projectRoot, "vercel.json", '{"buildCommand":"pnpm build"}');
+  const stale = vercel.projectProvisioning.verification.probes.map((probe) =>
+    runConnectionProbe(probe, { projectRoot, homeDirectory }),
+  );
+  assert.equal(stale.find((probe) => probe.id === "atomic-deploy").passed, false);
+
+  write(projectRoot, "vercel.json", JSON.stringify({ buildCommand: "npx convex deploy --cmd 'pnpm build'" }));
+  const ready = vercel.projectProvisioning.verification.probes.map((probe) =>
+    runConnectionProbe(probe, { projectRoot, homeDirectory }),
+  );
+  assert.equal(ready.every((probe) => probe.passed), true);
 });
 
 test("project-only providers never invent an agent-tool authorization phase", (t) => {

--- a/scripts/lib/deployment-coherence.mjs
+++ b/scripts/lib/deployment-coherence.mjs
@@ -1,0 +1,29 @@
+export function inspectDeploymentBlueprint({ netlifySource = "", vercelSource = "" } = {}) {
+  const hasNetlify = Boolean(netlifySource.trim());
+  const hasVercel = Boolean(vercelSource.trim());
+  if (!hasNetlify && !hasVercel) {
+    return { status: "SKIP", detail: "no downstream product deployment exists in this tool repository" };
+  }
+  if (hasNetlify && hasVercel) {
+    return { status: "FAIL", detail: "both netlify.toml and vercel.json are present; keep only the selected deployment adapter" };
+  }
+  if (hasNetlify) {
+    const passed = netlifySource.includes("npx convex deploy --cmd 'pnpm build'");
+    return {
+      status: passed ? "PASS" : "FAIL",
+      detail: passed ? "" : "netlify.toml must deploy Convex before the frontend build",
+    };
+  }
+
+  let document;
+  try {
+    document = JSON.parse(vercelSource);
+  } catch {
+    return { status: "FAIL", detail: "vercel.json is not valid JSON" };
+  }
+  const passed = document.buildCommand === "npx convex deploy --cmd 'pnpm build'";
+  return {
+    status: passed ? "PASS" : "FAIL",
+    detail: passed ? "" : "vercel.json buildCommand must deploy Convex before the frontend build",
+  };
+}

--- a/scripts/lib/deployment-coherence.test.mjs
+++ b/scripts/lib/deployment-coherence.test.mjs
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { inspectDeploymentBlueprint } from "./deployment-coherence.mjs";
+
+describe("deployment blueprint coherence", () => {
+  it("accepts the Netlify default", () => {
+    expect(inspectDeploymentBlueprint({ netlifySource: "command = \"npx convex deploy --cmd 'pnpm build'\"" }).status).toBe("PASS");
+  });
+
+  it("accepts the Vercel alternative", () => {
+    expect(
+      inspectDeploymentBlueprint({
+        vercelSource: JSON.stringify({ buildCommand: "npx convex deploy --cmd 'pnpm build'" }),
+      }).status,
+    ).toBe("PASS");
+  });
+
+  it("rejects a stale Vercel build and two active adapters", () => {
+    expect(inspectDeploymentBlueprint({ vercelSource: '{"buildCommand":"pnpm build"}' }).status).toBe("FAIL");
+    expect(inspectDeploymentBlueprint({ netlifySource: "x", vercelSource: "{}" }).status).toBe("FAIL");
+  });
+});

--- a/scripts/lib/provider-selection.test.mjs
+++ b/scripts/lib/provider-selection.test.mjs
@@ -86,3 +86,13 @@ test("the product brief requires the versioned provider selection", () => {
   expect(schema.required).toContain("providerSelection");
   expect(schema.properties.providerSelection.$ref).toBe("provider-selection.schema.json");
 });
+
+test("vercel can be selected as alternative deployment provider", () => {
+  expect(resolveProviderSelection({ deployment: "vercel" })).toEqual({
+    billing: "stripe",
+    email: "resend",
+    analytics: "posthog",
+    deployment: "vercel",
+    tracking: "linear",
+  });
+});

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -19,6 +19,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { inspectProductionBillingEnvironment } from "./lib/billing-coherence.mjs";
+import { inspectDeploymentBlueprint } from "./lib/deployment-coherence.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const read = (p) => (existsSync(join(root, p)) ? readFileSync(join(root, p), "utf8") : "");
@@ -70,12 +71,11 @@ add(
 
 // The public URL is env-driven per environment; the prod value is audited in the
 // --prod section below. Locally, the blueprint is the thing that must be intact:
-const blueprint = read("netlify.toml");
-add(
-  "deploy blueprint intact",
-  blueprint ? (/convex deploy/.test(blueprint) ? "PASS" : "FAIL") : "SKIP",
-  blueprint ? (/convex deploy/.test(blueprint) ? "" : "netlify.toml no longer deploys Convex before the frontend build") : "no downstream product deployment exists in this tool repository",
-);
+const deployment = inspectDeploymentBlueprint({
+  netlifySource: read("netlify.toml"),
+  vercelSource: read("vercel.json"),
+});
+add("selected deploy blueprint intact", deployment.status, deployment.detail);
 
 /* ---------- the CSP that actually ships ---------- */
 
@@ -150,7 +150,7 @@ console.log(
   failed
     ? `\nNOT READY — ${failed} blocking issue(s). Every one above ships a real incident: test payments, dead email, or an open seed gate.\n`
     : withProd
-      ? "\nREADY — code, build, tests and the prod deployment all check out. The go-live checklist in deploy-netlify.md covers the two manual webhooks.\n"
+      ? "\nREADY — code, build, tests and the prod deployment all check out. The selected deployment guide covers URL, domain, callback, and webhook acceptance.\n"
       : "\nCODE READY — now run `pnpm preflight --prod` to audit the real deployment before launch.\n",
 );
 process.exit(failed ? 1 : 0);

--- a/scripts/provider-login.mjs
+++ b/scripts/provider-login.mjs
@@ -1,15 +1,14 @@
 #!/usr/bin/env node
 /**
- * pnpm provider:login <stripe|netlify|github|21st>
+ * pnpm provider:login <stripe|netlify|vercel|github|21st>
  *
  * One journey per provider: install the official CLI if it is missing, then run its
  * browser OAuth login and wait for consent. The terminal never carries a credential —
  * the browser approval IS the authentication, and the CLI stores what it receives in
  * its own machine-local config, outside this repository.
  *
- * Install sources are the vendors' documented ones only (Homebrew on macOS/Linux,
- * Scoop/winget on Windows). When no installer is known for this platform the script
- * stops with the docs URL instead of guessing.
+ * Install sources are the vendors' documented package managers only. When no installer
+ * is known for this platform the script stops with the docs URL instead of guessing.
  */
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
@@ -19,7 +18,7 @@ import { fileURLToPath } from "node:url";
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
-// On Windows the vendor CLIs are batch shims (npm.cmd, netlify.cmd, scoop, winget, gh)
+// On Windows the vendor CLIs are batch shims (npm.cmd, netlify.cmd, vercel.cmd, scoop, winget, gh)
 // that spawnSync cannot exec without a shell — without this every provider login is dead
 // on win32. Every command and argument spawned below is a static literal from the
 // PROVIDERS catalog; no user input is ever interpolated into a shell string, so shell
@@ -62,6 +61,17 @@ const PROVIDERS = {
     login: ["netlify", "login"],
     // Read-only and account-scoped: it needs the credential and touches no site.
     verify: ["netlify", "api", "getCurrentUser", "--data", "{}"],
+  },
+  vercel: {
+    binary: "vercel",
+    docs: "https://vercel.com/docs/cli",
+    install: {
+      darwin: [["pnpm", "add", "--global", "vercel"]],
+      linux: [["pnpm", "add", "--global", "vercel"]],
+      win32: [["pnpm", "add", "--global", "vercel"]],
+    },
+    login: ["vercel", "login"],
+    verify: ["vercel", "whoami"],
   },
   github: {
     binary: "gh",


### PR DESCRIPTION
Supersedes #36 while preserving @Simultech369 original implementation commit and completing Vercel as a safe alternative deployment adapter.\n\nThank you @Simultech369 for the effort and the original implementation.\n\nWhat changed:\n- install and authenticate the official Vercel CLI, then verify with read-only vercel whoami\n- require an explicit existing-or-new project choice and a verified local project link\n- require one committed deployment adapter and the Convex-first build command\n- reject simultaneous Netlify and Vercel adapters in the shared preflight gate\n- add command_succeeds as a fixed, non-shell connection probe\n- document preview, production, environment, auth callback, webhook, custom-domain, revocation, and provider replacement flows\n- update README, AGENTS, connection docs, setup guidance, preflight, security guidance, platform notes, and stack references\n- add licensed light and dark Vercel marks with provenance\n- add connection, selection, and deployment-coherence regressions plus a tier-2 repair entry\n\nVerification:\n- focused provider suites: 30 passed\n- pnpm verify:full: passed\n- pnpm preflight: passed with tool-repository deployment checks correctly skipped\n\nCloses #20.