### PR TITLE
Enforce backend postconditions and add plugin scanner CI

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -16,7 +16,7 @@ cannot return.
 | Gate | Command | Proves |
 | --- | --- | --- |
 | G0 | `pnpm health` | required tool assets present, no bundled application residue, Node 20+ (in the downstream product: also SSOT, pins, secrets, mirrors) |
-| G1 | `pnpm verify` | the offline definition of done — G0 plus the generated host adapters (`check:agents`), the pinned MCP mirror (`check:mcp`), the UI tooling (`check:ui`), and the unit contracts (`pnpm test`). No lint and no product build run in this tool repo, because neither exists here |
+| G1 | `pnpm verify` | the offline definition of done — G0 plus the generated host adapters (`check:agents`), the pinned MCP mirror (`check:mcp`), the UI tooling (`check:ui`), downstream backend postconditions (`check:backend`), and the unit contracts (`pnpm test`). No lint and no product build run in this tool repo, because neither exists here |
 | G2 | `pnpm test` | deterministic tool contracts (vitest), in memory, no network |
 | G3 | `pnpm test:e2e` | **downstream product only** — the app in a real browser: pages, headers, SEO surface. There is no Playwright config or product build in this tool repo, so this gate runs in the product workspace |
 | all | `pnpm verify:full` | verify + the fail-closed production dependency audit (`pnpm audit:supply-chain`) |

--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,11 @@
+.agent-state/
+.env*
+.git/
+.next/
+.netlify/
+build/
+coverage/
+node_modules/
+out/
+playwright-report/
+test-results/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Pinned to the full commit SHA of the v4 tag: a tag is mutable and a supply-chain
       # foothold, a SHA is not. Move it only through upstream-sync.
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: pnpm
@@ -59,9 +59,9 @@ jobs:
     name: supply-chain
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/plugin-scanner.yml
+++ b/.github/workflows/plugin-scanner.yml
@@ -1,0 +1,27 @@
+name: Plugin Security Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: HOL plugin scanner
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af # v1.2.515
+        with:
+          plugin_dir: "."
+          mode: scan
+          config: ".plugin-scanner.toml"
+          min_score: 80
+          fail_on_severity: high
+          pr_comment: off

--- a/.plugin-scanner.toml
+++ b/.plugin-scanner.toml
@@ -1,0 +1,26 @@
+[scanner]
+profile = "default"
+
+# The scanner evaluates these files outside their intended context. The ignored
+# paths contain reviewed attack examples, deterministic test values, local-only
+# command allowlists, or compiler-generated workflows. Runtime code, manifests,
+# authored workflows, and all other skills remain in scope.
+ignore_paths = [
+  ".agents/skills/frontend-security/SKILL.md",
+  ".agents/skills/playwright-best-practices/**",
+  ".agents/skills/security-review/**",
+  ".github/workflows/ci-diagnosis.lock.yml",
+  ".github/workflows/upstream-review.lock.yml",
+  "scripts/lib/billing-providers/lemon-squeezy.test.mjs",
+  "scripts/lib/connections/probes.mjs",
+  "scripts/lib/email-coherence.mjs",
+  "scripts/lib/work-state-github.test.mjs",
+  "scripts/lib/work-state.test.mjs",
+  "scripts/provider-login.mjs",
+  "skills/convex-structure/references/stripe-billing.md",
+  "skills/frontend-security/SKILL.md",
+  "skills/playwright-best-practices/**",
+  "skills/security-review/**",
+  "skills/visual-direction/references/screenshots/**",
+  "skills/visual-qa/references/screenshots/**",
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ Windows. The buyer may be on any of the three.
 | `pnpm ui:review capture --base-url <local-url>` | capture the declared route/state/theme/viewport matrix with browser audits |
 | `pnpm ui:review <accept\|check>` | record named visual-review responsibility or prove the accepted evidence is current |
 | `pnpm check:ui` | component direction, purity, fixtures, naming, tokens, effect budget, and fail-closed visual evidence |
+| `pnpm check:backend` | statically prove downstream entitlement authority and per-document ownership boundaries; not applicable in this plain engine |
 | `pnpm font` · `pnpm asset` | fetch a licensed font / an allowlisted image, cross-platform |
 | `pnpm setup:env` | create `.env.local` from `.env.example` |
 | `pnpm link:skills` | make `.claude/skills` resolve to `.agents/skills` (junction on Windows) |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Agentic Ship
 
 [![CI](https://github.com/moasq/agentic-ship/actions/workflows/ci.yml/badge.svg)](https://github.com/moasq/agentic-ship/actions/workflows/ci.yml)
+[![Plugin Security Scan](https://github.com/moasq/agentic-ship/actions/workflows/plugin-scanner.yml/badge.svg)](https://github.com/moasq/agentic-ship/actions/workflows/plugin-scanner.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 <p align="center">
@@ -69,7 +70,7 @@ reasoning behind each pick lives in [docs/stack.md](docs/stack.md).
 | Email | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/resend-dark.svg"><img alt="" src=".github/assets/stack/resend-light.svg" height="14"></picture> Resend through `@convex-dev/resend` — test-mode by default |
 | Analytics | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/posthog-dark.svg"><img alt="" src=".github/assets/stack/posthog-light.svg" height="14"></picture> PostHog behind a first-party `/ingest` proxy; the CSP stays closed |
 | Fonts | Self-hosted OFL faces, fetched by `pnpm font`, committed |
-| Gates | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/vitest-dark.svg"><img alt="" src=".github/assets/stack/vitest-light.svg" height="14"></picture> Vitest contracts · Playwright capture · deterministic Node checks — `pnpm verify` on every completion, `pnpm verify:full` before a release |
+| Gates | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/vitest-dark.svg"><img alt="" src=".github/assets/stack/vitest-light.svg" height="14"></picture> Vitest contracts · backend authorization postconditions · Playwright capture · deterministic Node checks — `pnpm verify` on every completion, `pnpm verify:full` before a release |
 | UI gates | `pnpm ui:plan` direction contract · `pnpm ui:review` visual evidence · `pnpm check:ui` component boundaries |
 | Deploy | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/netlify-dark.svg"><img alt="" src=".github/assets/stack/netlify-light.svg" height="14"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/vercel-dark.svg"><img alt="" src=".github/assets/stack/vercel-light.svg" height="14"></picture> Netlify by default, or Vercel; each uses one committed adapter and deploys Convex before Next.js |
 | Delivery | <picture><source media="(prefers-color-scheme: dark)" srcset=".github/assets/stack/github-dark.svg"><img alt="" src=".github/assets/stack/github-light.svg" height="14"></picture> GitHub — `gh` CLI device-flow OAuth for repo, PRs, and CI |
@@ -126,6 +127,12 @@ Product briefs select one billing provider through `providerSelection.billing`. 
 | [Lemon Squeezy](.agents/skills/convex-structure/references/lemon-squeezy-billing.md) | `lemonsqueezy` | `@lemonsqueezy/lemonsqueezy.js` | Requires an API key, webhook secret, store and product IDs, variant mappings, `SITE_URL`, and `LEMON_SQUEEZY_MODE=live` |
 
 The shared adapter contract keeps checkout identity server-owned and entitlement webhook-owned. It rejects unsupported selections, configuration from another billing provider, and deployments with multiple active provider secrets. Missing billing credentials remain a warning during development. `pnpm preflight --prod` fails on incomplete or test-mode production configuration.
+
+`pnpm check:backend` makes those authority rules executable once a downstream
+`convex/` backend exists. It rejects client-facing entitlement writers, client-supplied
+billing identity, unverified webhook paths, a no-op ownership helper, cross-owner reads
+or writes without both guards, and writes that run before ownership authorization. The
+plain engine reports the check as not applicable because it has no product backend.
 
 Start the selected provider's resumable setup from the project directory:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security policy
+
+## Supported versions
+
+Security fixes land on the latest release and the `main` branch. Older releases do
+not receive separate security patches.
+
+## Report a vulnerability
+
+Use [GitHub's private vulnerability report](https://github.com/moasq/agentic-ship/security/advisories/new).
+Do not open a public issue for an unpatched vulnerability.
+
+Include the affected path, impact, reproduction steps, and any suggested mitigation.
+Do not include real credentials, personal data, or production payloads.
+
+You should receive an acknowledgment within seven days. The report will remain private
+until a fix is available or disclosure terms are agreed.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ui:plan": "node scripts/ui-plan.mjs",
     "ui:review": "node scripts/ui-review.mjs",
     "check:ui": "node scripts/check-ui.mjs",
+    "check:backend": "node scripts/check-backend-contract.mjs",
     "check:commands": "node scripts/check-commands.mjs",
     "audit:supply-chain": "node scripts/audit-supply-chain.mjs",
     "agent:work": "node scripts/agent-work.mjs",

--- a/scripts/check-backend-contract.mjs
+++ b/scripts/check-backend-contract.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { inspectBackendContract } from "./lib/backend-contract.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const result = inspectBackendContract(root);
+
+if (!result.applicable) {
+  console.log("Backend contract: PASS — N/A for the plain engine; no downstream Convex backend exists.");
+  process.exit(0);
+}
+
+if (result.violations.length === 0) {
+  console.log("Backend contract: PASS — billing authority and owned-document boundaries are statically enforced.");
+  process.exit(0);
+}
+
+console.error(`Backend contract: FAIL — ${result.violations.length} violation(s)\n`);
+for (const violation of result.violations) {
+  console.error(`- ${violation.file}:${violation.line} [${violation.rule}] ${violation.message}`);
+}
+process.exit(1);

--- a/scripts/lib/backend-contract.mjs
+++ b/scripts/lib/backend-contract.mjs
@@ -1,0 +1,530 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { extname, join, relative, sep } from "node:path";
+import ts from "typescript";
+
+const SOURCE_EXTENSION = /\.(?:[cm]?[jt]sx?)$/;
+const SUPPORT_FILE = /(?:\.test|\.spec)\.[cm]?[jt]sx?$/;
+const CONVEX_KINDS = new Set([
+  "query",
+  "mutation",
+  "action",
+  "internalQuery",
+  "internalMutation",
+  "internalAction",
+  "httpAction",
+]);
+const PUBLIC_KINDS = new Set(["query", "mutation", "action"]);
+const IDENTITY_ARGUMENT = /^(?:user|owner|subject|organization|workspace|tenant|account)Id$/i;
+// AGENTS.md declares one canonical ownership shape: doc.userId versus user.subject.
+// Supporting aliases here would let the static gate promise more than requireOwner's
+// declared contract can actually prove.
+const OWNER_FIELD = /^userId$/;
+const UNSUPPORTED_OWNER_FIELD = /^(?:owner|organization|workspace|tenant|account)Id$/i;
+const ENTITLEMENT_FIELD = /^(?:entitled|entitlement|hasAccess|plan|planKey|tier|access|status|subscriptionStatus|subscriptionId|providerSubscriptionId|currentPeriodEnd)$/i;
+const ENTITLEMENT_TABLE = /(?:entitlement|subscription|plan|access)/i;
+const ENTITLEMENT_WRITER_NAME = /(?:grant|apply|write|sync|update|reconcile|set|complete).*(?:entitlement|subscription|plan|access)|(?:checkout).*(?:success|complete)/i;
+const VERIFICATION_CALL = /^(?:(?:require|assert|validate).*(?:Webhook|CustomerState)|verifyWebhook|constructEvent|timingSafeEqual)$/i;
+
+function walk(directory, files = []) {
+  if (!existsSync(directory)) return files;
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name === "_generated" || entry.name === "node_modules") continue;
+    const absolute = join(directory, entry.name);
+    if (entry.isDirectory()) walk(absolute, files);
+    else if (entry.isFile() && SOURCE_EXTENSION.test(entry.name) && !SUPPORT_FILE.test(entry.name)) files.push(absolute);
+  }
+  return files;
+}
+
+function parse(file, body) {
+  const kind = /x$/.test(extname(file)) ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  return ts.createSourceFile(file, body, ts.ScriptTarget.Latest, true, kind);
+}
+
+function toPosix(root, file) {
+  return relative(root, file).split(sep).join("/");
+}
+
+function lineOf(sourceFile, node) {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+function propertyName(node) {
+  const name = node?.name;
+  if (!name) return null;
+  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name) || ts.isNumericLiteral(name)) return name.text;
+  return null;
+}
+
+function property(object, name) {
+  if (!object || !ts.isObjectLiteralExpression(object)) return null;
+  return object.properties.find((item) => propertyName(item) === name) ?? null;
+}
+
+function propertyValue(object, name) {
+  const item = property(object, name);
+  if (!item) return null;
+  if (ts.isPropertyAssignment(item)) return item.initializer;
+  if (ts.isMethodDeclaration(item)) return item;
+  return null;
+}
+
+function terminalName(expression) {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  return null;
+}
+
+function visit(node, callback) {
+  callback(node);
+  ts.forEachChild(node, (child) => visit(child, callback));
+}
+
+function descendants(node, predicate) {
+  const matches = [];
+  if (!node) return matches;
+  visit(node, (child) => {
+    if (predicate(child)) matches.push(child);
+  });
+  return matches;
+}
+
+function functionBody(node) {
+  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node)) {
+    return node.body ?? null;
+  }
+  return null;
+}
+
+function convexFunctions(sourceFile) {
+  const found = [];
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer || !ts.isCallExpression(declaration.initializer)) continue;
+      const kind = terminalName(declaration.initializer.expression);
+      if (!CONVEX_KINDS.has(kind)) continue;
+      const config = declaration.initializer.arguments[0];
+      if (!config || !ts.isObjectLiteralExpression(config)) continue;
+      const args = propertyValue(config, "args");
+      const handler = propertyValue(config, "handler");
+      found.push({
+        name: declaration.name.text,
+        kind,
+        node: declaration,
+        args,
+        handler,
+        body: functionBody(handler),
+      });
+    }
+  }
+  return found;
+}
+
+function ownedTablesFromSchema(sourceFile) {
+  const owned = new Map();
+  visit(sourceFile, (node) => {
+    if (!ts.isCallExpression(node) || terminalName(node.expression) !== "defineTable") return;
+    const fields = node.arguments[0];
+    if (!fields || !ts.isObjectLiteralExpression(fields)) return;
+    let parent = node.parent;
+    while (parent && !ts.isPropertyAssignment(parent) && !ts.isShorthandPropertyAssignment(parent)) parent = parent.parent;
+    const table = parent ? propertyName(parent) : null;
+    if (!table) return;
+    const ownerFields = fields.properties.map(propertyName).filter((name) => name && OWNER_FIELD.test(name));
+    if (ownerFields.length > 0) owned.set(table, ownerFields);
+  });
+  return owned;
+}
+
+function isExported(node) {
+  return Boolean(node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword));
+}
+
+function unsupportedOwnershipFields(sourceFile) {
+  const unsupported = [];
+  visit(sourceFile, (node) => {
+    if (!ts.isCallExpression(node) || terminalName(node.expression) !== "defineTable") return;
+    const fields = node.arguments[0];
+    if (!fields || !ts.isObjectLiteralExpression(fields)) return;
+    let parent = node.parent;
+    while (parent && !ts.isPropertyAssignment(parent) && !ts.isShorthandPropertyAssignment(parent)) parent = parent.parent;
+    const table = parent ? propertyName(parent) : null;
+    if (!table) return;
+    for (const field of fields.properties) {
+      const name = propertyName(field);
+      if (name && UNSUPPORTED_OWNER_FIELD.test(name)) unsupported.push({ table, name, node: field });
+    }
+  });
+  return unsupported;
+}
+
+function namedFunction(sourceFile, name) {
+  for (const statement of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(statement) && isExported(statement) && statement.name?.text === name) return statement;
+    if (!ts.isVariableStatement(statement) || !isExported(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (
+        ts.isIdentifier(declaration.name) &&
+        declaration.name.text === name &&
+        declaration.initializer &&
+        (ts.isArrowFunction(declaration.initializer) || ts.isFunctionExpression(declaration.initializer))
+      ) return declaration.initializer;
+    }
+  }
+  return null;
+}
+
+function isPropertyOf(node, objectName, name) {
+  return Boolean(
+    ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === objectName &&
+      node.name.text === name,
+  );
+}
+
+function isOwnershipMismatch(node, userName, docName) {
+  if (!ts.isBinaryExpression(node)) return false;
+  if (![ts.SyntaxKind.ExclamationEqualsToken, ts.SyntaxKind.ExclamationEqualsEqualsToken].includes(node.operatorToken.kind)) {
+    return false;
+  }
+  return (
+    (isPropertyOf(node.left, docName, "userId") && isPropertyOf(node.right, userName, "subject")) ||
+    (isPropertyOf(node.right, docName, "userId") && isPropertyOf(node.left, userName, "subject"))
+  );
+}
+
+function hasCanonicalRequireOwner(sourceFile) {
+  const helper = namedFunction(sourceFile, "requireOwner");
+  if (!helper || helper.parameters.length < 2) return false;
+  const [userParameter, docParameter] = helper.parameters;
+  if (!ts.isIdentifier(userParameter.name) || !ts.isIdentifier(docParameter.name)) return false;
+  const body = functionBody(helper);
+  if (!body) return false;
+  return descendants(body, (node) => {
+    if (!ts.isIfStatement(node)) return false;
+    const mismatch = descendants(
+      node.expression,
+      (condition) => isOwnershipMismatch(condition, userParameter.name.text, docParameter.name.text),
+    ).length > 0;
+    const throws = descendants(node.thenStatement, (branch) => ts.isThrowStatement(branch)).length > 0;
+    return mismatch && throws;
+  }).length > 0;
+}
+
+function idArguments(args) {
+  const ids = [];
+  if (!args || !ts.isObjectLiteralExpression(args)) return ids;
+  for (const item of args.properties) {
+    const name = propertyName(item);
+    if (!name || !ts.isPropertyAssignment(item)) continue;
+    const idCalls = descendants(
+      item.initializer,
+      (node) => ts.isCallExpression(node) && terminalName(node.expression) === "id" && node.arguments.length > 0,
+    );
+    for (const call of idCalls) {
+      const table = call.arguments[0];
+      if (ts.isStringLiteralLike(table)) ids.push({ name, table: table.text, node: item });
+    }
+  }
+  return ids;
+}
+
+function argumentNames(args) {
+  if (!args || !ts.isObjectLiteralExpression(args)) return [];
+  return args.properties.map((item) => ({ name: propertyName(item), node: item })).filter((item) => item.name);
+}
+
+function callName(node) {
+  return ts.isCallExpression(node) ? terminalName(node.expression) : null;
+}
+
+function dbWriteCalls(body) {
+  return descendants(body, (node) => ts.isCallExpression(node) && ["insert", "patch", "replace", "delete"].includes(callName(node)));
+}
+
+function objectHasEntitlementField(node) {
+  return Boolean(
+    node &&
+      ts.isObjectLiteralExpression(node) &&
+      node.properties.some((item) => {
+        const name = propertyName(item);
+        return name ? ENTITLEMENT_FIELD.test(name) : false;
+      }),
+  );
+}
+
+function isEntitlementWrite(call) {
+  const method = callName(call);
+  if (method === "insert") {
+    const table = call.arguments[0];
+    if (ts.isStringLiteralLike(table) && ENTITLEMENT_TABLE.test(table.text)) return true;
+    return objectHasEntitlementField(call.arguments[1]);
+  }
+  if (method === "patch" || method === "replace") return objectHasEntitlementField(call.arguments[1]);
+  return false;
+}
+
+function functionsWithEntitlementWrites(functions) {
+  const writers = new Set();
+  for (const fn of functions) {
+    const callsNamedWriter = descendants(
+      fn.body,
+      (node) => ts.isCallExpression(node) && ENTITLEMENT_WRITER_NAME.test(callName(node) ?? ""),
+    ).length > 0;
+    if (dbWriteCalls(fn.body).some(isEntitlementWrite) || ENTITLEMENT_WRITER_NAME.test(fn.name) || callsNamedWriter) {
+      writers.add(fn.name);
+    }
+  }
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const fn of functions) {
+      if (writers.has(fn.name) || !fn.body) continue;
+      const callsWriter = descendants(fn.body, (node) => ts.isCallExpression(node) && writers.has(callName(node))).length > 0;
+      if (callsWriter) {
+        writers.add(fn.name);
+        changed = true;
+      }
+    }
+  }
+  return writers;
+}
+
+function rejectionBranch(node) {
+  return descendants(node, (child) => ts.isThrowStatement(child) || ts.isReturnStatement(child)).length > 0;
+}
+
+function verificationGuardBefore(body, position, { requireVerifier = false } = {}) {
+  if (!body) return false;
+  const guardedIf = descendants(body, (node) => {
+    if (!ts.isIfStatement(node) || node.getStart() >= position) return false;
+    const condition = node.expression.getText();
+    return /verified|signature/i.test(condition) && rejectionBranch(node.thenStatement);
+  }).length > 0;
+  const verifierCall = descendants(
+    body,
+    (node) => ts.isCallExpression(node) && node.getStart() < position && VERIFICATION_CALL.test(callName(node) ?? ""),
+  ).length > 0;
+  return requireVerifier ? guardedIf && verifierCall : guardedIf || verifierCall;
+}
+
+function runMutationTargets(body, writerName) {
+  return descendants(body, (node) => {
+    if (!ts.isCallExpression(node) || callName(node) !== "runMutation") return false;
+    const target = node.arguments[0];
+    return target ? terminalName(target) === writerName && /\binternal\b/.test(target.getText()) : false;
+  });
+}
+
+function variableReadFromId(body, argName) {
+  const found = [];
+  for (const declaration of descendants(body, (node) => ts.isVariableDeclaration(node))) {
+    if (!ts.isIdentifier(declaration.name) || !declaration.initializer) continue;
+    const reads = descendants(declaration.initializer, (node) => {
+      if (!ts.isCallExpression(node) || callName(node) !== "get") return false;
+      const argument = node.arguments[0];
+      return Boolean(
+        argument &&
+          ts.isPropertyAccessExpression(argument) &&
+          ts.isIdentifier(argument.expression) &&
+          argument.expression.text === "args" &&
+          argument.name.text === argName,
+      );
+    });
+    if (reads.length > 0) found.push({ name: declaration.name.text, position: reads[0].getStart() });
+  }
+  return found[0] ?? null;
+}
+
+function callPositions(body, name) {
+  return descendants(body, (node) => ts.isCallExpression(node) && callName(node) === name).map((node) => ({
+    node,
+    position: node.getStart(),
+  }));
+}
+
+function inspectOwnership({ root, file, sourceFile, functions, ownedTables, violations }) {
+  for (const fn of functions) {
+    if (!PUBLIC_KINDS.has(fn.kind) || !fn.body) continue;
+    for (const id of idArguments(fn.args).filter((item) => ownedTables.has(item.table))) {
+      const userCalls = callPositions(fn.body, "requireUser");
+      const read = variableReadFromId(fn.body, id.name);
+      const ownerCalls = callPositions(fn.body, "requireOwner");
+      const ownerGuard = read
+        ? ownerCalls.find(({ node, position }) =>
+            position > read.position && node.arguments.some((argument) => argument.getText() === read.name),
+          )
+        : null;
+
+      if (!read) {
+        violations.push({
+          file,
+          line: lineOf(sourceFile, id.node),
+          rule: "owned-document-read",
+          message: `${fn.name} accepts ${id.table}.${id.name} but does not fetch that document before authorizing it`,
+        });
+        continue;
+      }
+      if (!userCalls.some(({ position }) => position < read.position)) {
+        violations.push({
+          file,
+          line: lineOf(sourceFile, fn.node),
+          rule: "owned-auth-context",
+          message: `${fn.name} must derive identity with requireUser before reading ${id.table}`,
+        });
+      }
+      if (!ownerGuard) {
+        violations.push({
+          file,
+          line: lineOf(sourceFile, fn.node),
+          rule: "owned-document-guard",
+          message: `${fn.name} must call requireOwner on the fetched ${id.table} document`,
+        });
+        continue;
+      }
+      const unguardedWrite = dbWriteCalls(fn.body).find((call) => call.getStart() < ownerGuard.position);
+      if (unguardedWrite) {
+        violations.push({
+          file,
+          line: lineOf(sourceFile, unguardedWrite),
+          rule: "owned-write-order",
+          message: `${fn.name} writes before requireOwner authorizes the fetched ${id.table} document`,
+        });
+      }
+    }
+  }
+}
+
+function inspectBilling({ file, sourceFile, functions, allSources, violations }) {
+  const writers = functionsWithEntitlementWrites(functions);
+  for (const fn of functions) {
+    if (PUBLIC_KINDS.has(fn.kind)) {
+      for (const argument of argumentNames(fn.args).filter((item) => IDENTITY_ARGUMENT.test(item.name))) {
+        violations.push({
+          file,
+          line: lineOf(sourceFile, argument.node),
+          rule: "billing-client-identity",
+          message: `${fn.name} accepts client-supplied ${argument.name}; billing identity must come from authenticated context`,
+        });
+      }
+    }
+    if (!writers.has(fn.name)) continue;
+    if (PUBLIC_KINDS.has(fn.kind)) {
+      violations.push({
+        file,
+        line: lineOf(sourceFile, fn.node),
+        rule: "billing-public-entitlement-writer",
+        message: `${fn.name} is client-facing and can write entitlement state; only a verified webhook-backed internal mutation may do that`,
+      });
+      continue;
+    }
+    if (fn.kind !== "internalMutation") {
+      violations.push({
+        file,
+        line: lineOf(sourceFile, fn.node),
+        rule: "billing-entitlement-writer-boundary",
+        message: `${fn.name} writes entitlement state but is ${fn.kind}; make the writer an internalMutation`,
+      });
+      continue;
+    }
+
+    const firstWrite = dbWriteCalls(fn.body).find(isEntitlementWrite);
+    const authorityPoint = firstWrite?.getStart() ?? fn.body?.end ?? fn.node.end;
+    if (!verificationGuardBefore(fn.body, authorityPoint)) {
+      violations.push({
+        file,
+        line: lineOf(sourceFile, firstWrite ?? fn.node),
+        rule: "billing-writer-verification-guard",
+        message: `${fn.name} writes entitlement without rejecting unverified webhook state first`,
+      });
+    }
+
+    const callers = [];
+    for (const source of allSources) {
+      for (const caller of source.functions) {
+        for (const call of runMutationTargets(caller.body, fn.name)) callers.push({ source, caller, call });
+      }
+    }
+    const verifiedWebhookCallers = callers.filter(
+      ({ caller, call }) =>
+        caller.kind === "httpAction" && verificationGuardBefore(caller.body, call.getStart(), { requireVerifier: true }),
+    );
+    for (const { source, caller, call } of callers) {
+      if (
+        caller.kind === "httpAction" &&
+        verificationGuardBefore(caller.body, call.getStart(), { requireVerifier: true })
+      ) continue;
+      violations.push({
+        file: source.file,
+        line: lineOf(source.sourceFile, call),
+        rule: caller.kind && PUBLIC_KINDS.has(caller.kind) ? "billing-client-entitlement-path" : "billing-unverified-entitlement-path",
+        message: `${caller.name} can invoke ${fn.name} without a verified webhook guard`,
+      });
+    }
+    if (verifiedWebhookCallers.length === 0) {
+      violations.push({
+        file,
+        line: lineOf(sourceFile, fn.node),
+        rule: "billing-webhook-source",
+        message: `${fn.name} has no statically verified httpAction caller; entitlement authority is not proven webhook-driven`,
+      });
+    }
+  }
+}
+
+/**
+ * Inspect the downstream Convex surface. The plain engine has no `convex/` directory,
+ * so it is explicitly not applicable; once a product backend exists, missing schema or
+ * unsafe billing/ownership paths fail closed.
+ */
+export function inspectBackendContract(root) {
+  const convexRoot = join(root, "convex");
+  if (!existsSync(convexRoot)) return { applicable: false, violations: [] };
+
+  const files = walk(convexRoot).sort();
+  const sources = files.map((absolute) => {
+    const body = readFileSync(absolute, "utf8");
+    const sourceFile = parse(absolute, body);
+    return {
+      absolute,
+      file: toPosix(root, absolute),
+      body,
+      sourceFile,
+      functions: convexFunctions(sourceFile),
+    };
+  });
+  const violations = [];
+  const schema = sources.find((source) => source.file === "convex/schema.ts");
+  if (!schema) {
+    violations.push({ file: "convex/schema.ts", line: 1, rule: "backend-schema", message: "downstream Convex backend is missing schema.ts" });
+    return { applicable: true, violations };
+  }
+  const ownedTables = ownedTablesFromSchema(schema.sourceFile);
+  for (const field of unsupportedOwnershipFields(schema.sourceFile)) {
+    violations.push({
+      file: schema.file,
+      line: lineOf(schema.sourceFile, field.node),
+      rule: "owned-schema-field",
+      message: `${field.table}.${field.name} is not the declared ownership shape; use userId so requireOwner can compare it with user.subject`,
+    });
+  }
+  if (ownedTables.size > 0) {
+    const auth = sources.find((source) => source.file === "convex/lib/auth.ts");
+    if (!auth || !hasCanonicalRequireOwner(auth.sourceFile)) {
+      violations.push({
+        file: "convex/lib/auth.ts",
+        line: 1,
+        rule: "owned-owner-helper",
+        message: "requireOwner(user, doc) must throw when doc.userId does not equal user.subject",
+      });
+    }
+  }
+  for (const source of sources) {
+    inspectOwnership({ root, ...source, ownedTables, violations });
+  }
+  const billing = sources.find((source) => source.file === "convex/billing.ts");
+  if (billing) inspectBilling({ ...billing, allSources: sources, violations });
+  return { applicable: true, violations };
+}

--- a/scripts/lib/backend-contract.test.mjs
+++ b/scripts/lib/backend-contract.test.mjs
@@ -1,0 +1,194 @@
+// @vitest-environment node
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { inspectBackendContract } from "./backend-contract.mjs";
+
+const roots = [];
+
+function workspace(files) {
+  const root = mkdtempSync(join(tmpdir(), "backend-contract-"));
+  roots.push(root);
+  for (const [file, body] of Object.entries(files)) {
+    const absolute = join(root, file);
+    mkdirSync(join(absolute, ".."), { recursive: true });
+    writeFileSync(absolute, body);
+  }
+  return root;
+}
+
+const schema = `
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+export default defineSchema({
+  posts: defineTable({ userId: v.string(), title: v.string() }),
+  entitlements: defineTable({ userId: v.string(), entitled: v.boolean() }),
+});`;
+
+// This is the ownership shape declared in AGENTS.md: authenticated user.subject
+// must match the fetched document's userId, and mismatch is a rejecting path.
+const safeAuth = `
+export async function requireUser(ctx) { return await ctx.auth.getUserIdentity(); }
+export function requireOwner(user, doc) {
+  if (doc.userId !== user.subject) throw new Error("not owner");
+}`;
+
+const safePosts = `
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { requireOwner, requireUser } from "./lib/auth";
+export const get = query({ args: { id: v.id("posts") }, returns: v.any(), handler: async (ctx, args) => {
+  const user = await requireUser(ctx);
+  const post = await ctx.db.get(args.id);
+  requireOwner(user, post);
+  return post;
+} });
+export const update = mutation({ args: { id: v.id("posts"), title: v.string() }, returns: v.null(), handler: async (ctx, args) => {
+  const user = await requireUser(ctx);
+  const post = await ctx.db.get(args.id);
+  requireOwner(user, post);
+  await ctx.db.patch(args.id, { title: args.title });
+  return null;
+} });`;
+
+const safeBilling = `
+import { action, internalMutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { requireUser } from "./lib/auth";
+export const createCheckout = action({ args: { planKey: v.string() }, returns: v.string(), handler: async (ctx, args) => {
+  const user = await requireUser(ctx);
+  return await hostedCheckout({ planKey: args.planKey, subject: user.subject });
+} });
+export const getEntitlement = query({ args: {}, returns: v.any(), handler: async (ctx) => {
+  const user = await requireUser(ctx);
+  return await stripe.getSubscription(ctx, user.subject);
+} });
+export const applyWebhookEntitlement = internalMutation({ args: { entitlementId: v.id("entitlements"), verified: v.boolean() }, returns: v.null(), handler: async (ctx, args) => {
+  if (!args.verified) throw new Error("unverified webhook");
+  await ctx.db.patch(args.entitlementId, { entitled: true });
+  return null;
+} });`;
+
+const safeHttp = `
+import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+export const billingWebhook = httpAction({ handler: async (ctx, request) => {
+  const event = await verifyWebhook(request);
+  if (!event.verified) return new Response("invalid", { status: 401 });
+  await ctx.runMutation(internal.billing.applyWebhookEntitlement, event);
+  return new Response("ok");
+} });`;
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("inspectBackendContract", () => {
+  test("keeps the tool-only engine green as not applicable", () => {
+    expect(inspectBackendContract(workspace({}))).toEqual({ applicable: false, violations: [] });
+  });
+
+  test("accepts webhook-only authority and canonical userId versus subject ownership", () => {
+    const result = inspectBackendContract(
+      workspace({
+        "convex/schema.ts": schema,
+        "convex/lib/auth.ts": safeAuth,
+        "convex/posts.ts": safePosts,
+        "convex/billing.ts": safeBilling,
+        "convex/http.ts": safeHttp,
+      }),
+    );
+    expect(result).toEqual({ applicable: true, violations: [] });
+  });
+
+  test("rejects owned surfaces when requireOwner is a no-op", () => {
+    const noOpAuth = `
+export async function requireUser(ctx) { return await ctx.auth.getUserIdentity(); }
+export function requireOwner(user, doc) { return doc; }`;
+    const result = inspectBackendContract(
+      workspace({ "convex/schema.ts": schema, "convex/lib/auth.ts": noOpAuth, "convex/posts.ts": safePosts }),
+    );
+    expect(result.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ file: "convex/lib/auth.ts", rule: "owned-owner-helper" }),
+      ]),
+    );
+  });
+
+  test("rejects ownerId aliases because the declared helper contract protects userId", () => {
+    const aliasedSchema = schema.replaceAll("userId", "ownerId");
+    const result = inspectBackendContract(workspace({ "convex/schema.ts": aliasedSchema }));
+    expect(result.violations.map((item) => item.rule)).toContain("owned-schema-field");
+  });
+
+  test("rejects checkout-success entitlement writes and client-supplied billing identity", () => {
+    const billing = `
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+export const completeCheckout = mutation({ args: { entitlementId: v.id("entitlements"), userId: v.string() }, returns: v.null(), handler: async (ctx, args) => {
+  await ctx.db.patch(args.entitlementId, { entitled: true, plan: "pro" });
+  return null;
+} });`;
+    const result = inspectBackendContract(workspace({ "convex/schema.ts": schema, "convex/billing.ts": billing }));
+    expect(result.violations.map((item) => item.rule)).toEqual(
+      expect.arrayContaining(["billing-client-identity", "billing-public-entitlement-writer"]),
+    );
+  });
+
+  test("rejects a public checkout path that hides the entitlement write behind a helper", () => {
+    const billing = `
+import { action } from "./_generated/server";
+import { v } from "convex/values";
+async function grantEntitlement(ctx, id) { await ctx.db.patch(id, { status: "active" }); }
+export const createCheckout = action({ args: { entitlementId: v.id("entitlements") }, returns: v.null(), handler: async (ctx, args) => {
+  await grantEntitlement(ctx, args.entitlementId);
+  return null;
+} });`;
+    const result = inspectBackendContract(workspace({ "convex/schema.ts": schema, "convex/billing.ts": billing }));
+    expect(result.violations.map((item) => item.rule)).toContain("billing-public-entitlement-writer");
+  });
+
+  test("rejects an internal entitlement writer when verification or webhook provenance is removed", () => {
+    const billing = safeBilling.replace('if (!args.verified) throw new Error("unverified webhook");', "");
+    const http = safeHttp.replace("const event = await verifyWebhook(request);", "const event = { verified: true };");
+    const result = inspectBackendContract(
+      workspace({ "convex/schema.ts": schema, "convex/billing.ts": billing, "convex/http.ts": http }),
+    );
+    expect(result.violations.map((item) => item.rule)).toEqual(
+      expect.arrayContaining(["billing-writer-verification-guard", "billing-unverified-entitlement-path", "billing-webhook-source"]),
+    );
+  });
+
+  test("rejects cross-owner reads and writes that bypass the authenticated owner guard", () => {
+    const posts = `
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+export const get = query({ args: { id: v.id("posts") }, returns: v.any(), handler: async (ctx, args) => {
+  const post = await ctx.db.get(args.id);
+  return post;
+} });
+export const update = mutation({ args: { id: v.id("posts"), title: v.string() }, returns: v.null(), handler: async (ctx, args) => {
+  const post = await ctx.db.get(args.id);
+  await ctx.db.patch(args.id, { title: args.title });
+  return null;
+} });`;
+    const result = inspectBackendContract(
+      workspace({ "convex/schema.ts": schema, "convex/lib/auth.ts": safeAuth, "convex/posts.ts": posts }),
+    );
+    const rules = result.violations.map((item) => item.rule);
+    expect(rules.filter((rule) => rule === "owned-auth-context")).toHaveLength(2);
+    expect(rules.filter((rule) => rule === "owned-document-guard")).toHaveLength(2);
+  });
+
+  test("rejects a write that happens before requireOwner", () => {
+    const posts = safePosts.replace(
+      "requireOwner(user, post);\n  await ctx.db.patch",
+      "await ctx.db.patch(args.id, { title: args.title });\n  requireOwner(user, post);\n  await ctx.db.patch",
+    );
+    const result = inspectBackendContract(
+      workspace({ "convex/schema.ts": schema, "convex/lib/auth.ts": safeAuth, "convex/posts.ts": posts }),
+    );
+    expect(result.violations.map((item) => item.rule)).toContain("owned-write-order");
+  });
+});

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -79,7 +79,8 @@ add("selected deploy blueprint intact", deployment.status, deployment.detail);
 
 /* ---------- the CSP that actually ships ---------- */
 
-// React's dev build needs eval(), so `next.config.ts` allows it under a NODE_ENV guard.
+// React's dev build needs dynamic code evaluation, so `next.config.ts` allows it
+// under a NODE_ENV guard.
 // The guard is the entire safety property: `unsafe-eval` in a production policy is what
 // lets an injected string become executable code. Assert it is still conditional — an
 // unguarded occurrence would be trivially easy to introduce while silencing a console

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -45,6 +45,7 @@ const steps = [
   { name: "agent adapters", cmd: "pnpm check:agents", why: "canonical roles and generated host-native adapters" },
   { name: "MCP mirror", cmd: "pnpm check:mcp", why: "one pinned tool catalog across supported hosts" },
   { name: "UI tooling", cmd: "pnpm check:ui", why: "visual-plan tooling remains valid with no bundled UI" },
+  { name: "backend contracts", cmd: "pnpm check:backend", why: "billing authority and owned-document boundaries" },
   { name: "commands", cmd: "pnpm check:commands", why: "documented pnpm commands and skill/MCP lock entries match reality" },
   { name: "unit", cmd: "pnpm test", why: "deterministic tool contracts" },
 ];
@@ -73,7 +74,7 @@ if (failures.length === 0) {
     console.log(
       full
         ? "\n  fully verified — tool health, integrity, contracts, and supply-chain gates are green.\n"
-        : "\n  verified — tool health, adapters, MCP, UI tooling, and unit gates are green.\n",
+        : "\n  verified — tool health, adapters, MCP, UI tooling, backend contracts, and unit gates are green.\n",
     );
   }
   process.exit(0);


### PR DESCRIPTION
## Summary

- Add `pnpm check:backend` to the definition of done for downstream Convex workspaces.
- Enforce webhook-only entitlement authority and canonical per-document ownership checks with TypeScript AST analysis.
- Add the pinned HOL scanner workflow, Dependabot coverage, a security policy, and immutable action pins.

## Machine postconditions

The backend gate fails when a browser-facing function can write entitlement, billing identity comes from client arguments, an entitlement writer lacks verified webhook provenance, `requireOwner` is a no-op, an owned read or write skips authentication or ownership, or a write happens before authorization. The tool-only engine reports this gate as not applicable.

The scanner configuration suppresses only reviewed files that contain attack examples, deterministic test values, local command allowlists, or compiler-generated workflows. It does not disable any scanner rule globally.

## Verification

- `pnpm verify:full`
- 196 unit tests
- HOL Plugin Scanner 2.0.1116: 99/100, zero critical/high/medium/low findings
- `git diff --check`