### PR TITLE
chore: bound automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,19 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # These majors must move with the repository's Node/runtime and parser
+      # contracts, not as isolated lockfile bumps.
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # The official gh-aw compiler owns these generated workflow lock files.
+      - dependency-name: github/gh-aw-actions/setup


### PR DESCRIPTION
## Summary\n\n- defer TypeScript and Node type major updates until the parser/runtime contracts move with them\n- stop Dependabot from editing gh-aw compiler-owned workflow lock files\n\n## Verification\n\n- 
> agentic-ship@0.1.0 verify:full /private/var/folders/k9/63p0qv3d0c39zyh9qb66d_xm0000gn/T/agentic-ship-dependabot-policy.br7vXP50eJ
> node scripts/verify.mjs --full

  health … ok
  agent adapters … ok
  MCP mirror … ok
  UI tooling … ok
  backend contracts … ok
  commands … ok
  unit … ok
  supply chain … ok

  fully verified — tool health, integrity, contracts, and supply-chain gates are green.